### PR TITLE
fix(ci): drop keytar native-build deps from npm-publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -20,13 +20,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libsecret-1-dev
-          sudo apt-get install -y gnome-keyring
-          sudo apt-get install -y libgnome-keyring-dev
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary
The \`npm-publish.yml\` workflow installs \`libsecret-1-dev\`, \`gnome-keyring\`, and \`libgnome-keyring-dev\` for keytar's native build. After the \`@napi-rs/keyring\` swap in #47 none of those are needed — and \`libgnome-keyring-dev\` no longer exists on Ubuntu 24.04, which is why the publish job for #47 failed and **v0.3.62 never reached npm** (registry still on v0.3.60).

## Test plan
- [x] CI passes (same lint + test jobs as main, no changes to those)
- [ ] After merge: confirm \`npm view weather-cli-16bit version\` returns \`0.3.62\`
- [ ] After merge: confirm GitHub Release \`v0.3.62\` is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)