### PR TITLE
feat: weather status command + shared cache across all commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,237 +1,141 @@
-# weather-cli-16bit v0.3.62
+# weather-cli-16bit
 
 [![npm version](https://badge.fury.io/js/weather-cli-16bit.svg)](https://www.npmjs.com/package/weather-cli-16bit)
 [![CI](https://github.com/deephouse23/weather-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/deephouse23/weather-cli/actions/workflows/ci.yml)
 ![License](https://img.shields.io/badge/license-MIT-blue)
 ![Node.js](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen)
 
-Part of the 16bitweather suite of weather tools.
+An OpenWeatherMap CLI that parses location words without quotes — `weather San Ramon CA` just works.
 
-A command-line weather application with smart location parsing, responsive terminal display, and secure API key storage.
-
-**No quotes needed — just type `weather San Ramon CA` from anywhere on your system.**
-
-## Installation
-
-### NPM Global Install (Recommended)
+## Install
 
 ```bash
 npm install -g weather-cli-16bit
-weather San Francisco CA
 ```
 
-### From Source
+Requires Node.js 20+ and a free OpenWeatherMap API key.
+
+## Setup
+
+```bash
+weather auth set     # store API key in the OS keychain
+weather auth test    # verify it works
+```
+
+Or set `WEATHER_API_KEY` in `.env` / your shell.
+
+## Usage
+
+```bash
+weather                         # interactive mode
+weather San Ramon CA            # current weather
+weather London                  # international
+weather 94583                   # US ZIP
+weather forecast Tokyo          # 24-hour forecast
+weather 5day Paris              # 5-day forecast
+weather compare "New York" London
+weather coords 37.7749,-122.4194
+weather --art --animate         # ASCII art scene
+```
+
+Units default to the region (°F in the US, °C elsewhere). Override with `--celsius`, `--fahrenheit`, or `-u metric|imperial`. Every call prefetches current + 24h + 5day + air-quality in one round-trip; subsequent commands for the same location in the next 30 min hit the local cache and return instantly.
+
+## Output
+
+```
+╭──────────────────────────────────────────────────────────────────────────────────╮
+│   San Ramon, US                                                                  │
+│                                                                                  │
+│   clear sky                             Sunrise:     06:16 AM                    │
+│   82°F                                  Sunset:      08:10 PM                    │
+│   Feels like: 82°F                      Air Quality: Good (AQI: 1)               │
+│   Humidity:   44%                       Min/Max:     73°F / 88°F                 │
+│   Pressure:   1015 hPa                  Wind:        5.99 mph @ 210°             │
+│                                         Visibility:  10.0 km                     │
+╰──────────────────────────────────────────────────────────────────────────────────╯
+```
+
+Layout collapses to a single column below ~68 cols.
+
+## Shell prompt / tmux
+
+`weather status` emits a single line and exits fast, reading only from the local cache. Safe to call on every prompt redraw — no network, no spinner. Exits `1` when the cache is cold so your prompt skips rendering.
+
+```bash
+weather status                   # ☀️ San Ramon 82°F ↑89 ↓73
+weather status --format compact  # ☀️ 82°F
+weather status --format minimal  # 82°F
+weather status --no-emoji        # San Ramon 82°F ↑89 ↓73
+```
+
+Wire it into starship (`~/.config/starship.toml`):
+
+```toml
+[custom.weather]
+command = "weather status --format compact"
+when = "weather status --format compact"
+format = "[$output]($style) "
+```
+
+Or tmux (`~/.tmux.conf`):
+
+```
+set -g status-right '#(weather status --format compact) | %H:%M'
+```
+
+Run `weather <location>` once to warm the cache. Subsequent `weather status` calls are free until the 30-min TTL expires.
+
+## Commands
+
+| Command                           | Description                        |
+| --------------------------------- | ---------------------------------- |
+| `weather [location]`              | Current weather (default)          |
+| `weather now [location]`          | Current weather (explicit)         |
+| `weather forecast [location]`     | 24-hour forecast                   |
+| `weather 5day [location]`         | 5-day forecast                     |
+| `weather compare <city1> <city2>` | Compare two cities                 |
+| `weather coords <lat,lon>`        | Weather by GPS coordinates         |
+| `weather status [location]`       | One-line output for prompts / tmux |
+| `weather config`                  | Set default location and units     |
+| `weather cache [-c\|--clean]`     | View / clear / prune the cache     |
+| `weather auth set\|test`          | Store or validate the API key      |
+| `weather interactive` / `i`       | Force interactive prompts          |
+
+## Options
+
+| Option               | Description                                   |
+| -------------------- | --------------------------------------------- |
+| `-u, --units <type>` | `metric`, `imperial`, `celsius`, `fahrenheit` |
+| `--celsius`          | Force °C                                      |
+| `--fahrenheit`       | Force °F                                      |
+| `-f, --forecast`     | Append 24-hour forecast to current weather    |
+| `--art`              | Render ASCII art scene above the weather box  |
+| `--art-only`         | Render only the ASCII art                     |
+| `--art-style <name>` | `default` or `retro`                          |
+| `--animate`          | Animate the scene (interactive TTY only)      |
+
+## Development
 
 ```bash
 git clone https://github.com/deephouse23/weather-cli.git
 cd weather-cli
 npm install
-npm link
+npm link                 # expose the `weather` binary locally
 ```
 
-### Requirements
-
-- Node.js v20.0.0 or higher
-- OpenWeatherMap API key (free at [openweathermap.org](https://openweathermap.org/api))
-
-### Setup
-
-```bash
-# Secure API key setup (recommended — stores in OS keychain)
-weather auth set
-
-# Test your API key
-weather auth test
-
-# Alternative: environment variable
-cp .env.example .env
-# Edit .env and add your OpenWeatherMap API key
-```
-
-## Usage
-
-### US States & Cities (no quotes needed)
-
-```bash
-weather CA                    # California
-weather NY                    # New York
-weather San Ramon CA          # San Ramon, California
-weather San Francisco         # Auto-detects SF
-```
-
-### International
-
-```bash
-weather London                # Auto-detects UK
-weather Tokyo                 # Auto-detects Japan
-weather BC                    # British Columbia, Canada
-weather Ontario               # Ontario, Canada
-```
-
-### All Commands
-
-```bash
-# Current weather
-weather San Ramon             # City name
-weather San Ramon CA          # City, State
-weather London                # International
-weather 94583                 # US Zip code
-
-# Forecasts
-weather forecast London       # 24-hour forecast
-weather 5day Tokyo            # 5-day forecast
-
-# Compare & coordinates
-weather compare "New York" London
-weather coords 37.7749,-122.4194
-
-# ASCII Art (animated)
-weather San Francisco --art --animate
-
-# Interactive mode
-weather                       # No arguments starts interactive mode
-
-# Configuration & cache
-weather config                # Set default location and units
-weather cache                 # View cache statistics
-weather cache -c              # Clear cache
-
-# Authentication
-weather auth set              # Store API key securely
-weather auth test             # Validate your API key
-```
-
-### Temperature Units
-
-```bash
-# Automatic regional detection
-weather London                # UK = Celsius
-weather "New York"            # US = Fahrenheit
-
-# Force specific units
-weather Tokyo --celsius
-weather Paris --fahrenheit
-weather Berlin -u metric
-weather Sydney -u imperial
-```
-
-## Display
+Scripts:
 
 ```
-╭──────────────────────────────────────────────────────────────────────────────────╮
-│                                                                                  │
-│   San Ramon, US                                    Sunrise: 06:16 AM             │
-│   clear sky                                        Sunset: 08:10 PM              │
-│   82°F                                             Air Quality: Good (AQI: 1)    │
-│   Feels like: 82°F                                 Min: 73°F / Max: 88°F         │
-│   Humidity: 44%                                     Wind: 5.99 mph               │
-│   Pressure: 1015 hPa                                Visibility: 10km             │
-│                                                                                  │
-╰──────────────────────────────────────────────────────────────────────────────────╯
+npm test             vitest
+npm run test:watch   vitest --watch
+npm run lint         eslint .
+npm run format       prettier --write .
+npm run dev          node --watch bin/weather.js
 ```
 
-Responsive layout adapts to terminal width (compact, medium, and full views).
+Stack: Vitest, ESLint (flat config), Prettier, Husky + lint-staged, Axios, Commander, Inquirer, boxen, chalk. Keys live in the OS keychain via `@napi-rs/keyring`.
 
-## Architecture
-
-```
-src/
-├── weather.js           # API calls and weather logic
-├── cache.js             # Caching with expiration
-├── display.js           # Terminal formatting and output
-├── config.js            # Configuration management
-├── api/
-│   ├── auth.js          # Secure authentication (keytar)
-│   └── http.js          # HTTP client with retry logic
-└── utils/
-    ├── errors.js        # Error handling utilities
-    ├── locationParser.js # Smart location parsing
-    └── validators.js    # Input validation
-
-tests/unit/
-├── cache.test.js        # Cache expiry, eviction, persistence
-├── config.test.js       # Config load/save, temp options
-├── display.test.js      # Formatting, air quality, data rows
-├── errors.test.js       # WeatherError, exit code mapping
-├── http.test.js         # Retry config, rate limiting
-├── locationParser.test.js # 17 location format tests
-├── validators.test.js   # Sanitization, coordinates, bounds
-└── weather.test.js      # Unit detection, temp conversion
-```
-
-## Features
-
-- **Smart Location Parsing** — no quotes needed, supports US states, Canadian provinces, country codes
-- **Secure API Keys** — OS keychain via `keytar`, fallback to env var
-- **Smart Caching** — 30-minute expiry, 100-entry limit, LRU eviction
-- **Responsive Display** — adapts to terminal width with color-coded output
-- **Forecasts** — 24-hour and 5-day, city comparison, GPS coordinates
-- **Retry Logic** — exponential backoff for network issues
-- **Animated ASCII Art** — animated weather scenes with `--art --animate`
-
-## Development
-
-### Prerequisites
-
-- Node.js v20+
-- npm
-
-### Scripts
-
-```bash
-npm test                 # Run all tests (Vitest)
-npm run test:watch       # Watch mode
-npm run test:coverage    # With coverage
-npm run lint             # ESLint
-npm run lint:fix         # ESLint with auto-fix
-npm run format           # Prettier format
-npm run format:check     # Check formatting
-npm run dev              # Dev mode with auto-restart
-```
-
-### Quality Tools
-
-- **Vitest** — 104 unit tests across 8 test files
-- **ESLint v9** — flat config with Prettier integration
-- **Prettier** — consistent code formatting
-- **Husky** — pre-commit hook runs lint-staged
-- **GitHub Actions CI** — lint + test matrix (Node 20, 22, 24)
-
-### Contributing
-
-1. Fork the repo
-2. Create feature branch: `git checkout -b feature/my-feature`
-3. Run checks: `npm test && npm run lint`
-4. Commit and push
-5. Open PR — auto-publishes to npm when merged
-
-## Command Reference
-
-| Command                           | Description                |
-| --------------------------------- | -------------------------- |
-| `weather [location]`              | Current weather            |
-| `weather now [location]`          | Current weather (explicit) |
-| `weather forecast [location]`     | 24-hour forecast           |
-| `weather 5day [location]`         | 5-day forecast             |
-| `weather compare <city1> <city2>` | Compare two cities         |
-| `weather coords <lat,lon>`        | Weather by GPS             |
-| `weather config`                  | Set defaults               |
-| `weather cache`                   | View cache stats           |
-| `weather cache -c`                | Clear cache                |
-| `weather auth set`                | Store API key              |
-| `weather auth test`               | Test API key               |
-
-### Options
-
-| Option               | Description                              |
-| -------------------- | ---------------------------------------- |
-| `-u, --units <type>` | Temperature units (metric/imperial/auto) |
-| `--celsius`          | Force Celsius display                    |
-| `--fahrenheit`       | Force Fahrenheit display                 |
-| `-f, --forecast`     | Include 24-hour forecast                 |
-| `-a, --alerts`       | Show weather alerts                      |
-| `--art`              | Display ASCII art weather scene          |
-| `--animate`          | Animate the ASCII art scene              |
+CI runs lint + the test suite on Node 20/22/24.
 
 ## License
 
@@ -239,8 +143,6 @@ MIT — see [LICENSE](LICENSE).
 
 ## Links
 
-- **NPM**: [weather-cli-16bit](https://www.npmjs.com/package/weather-cli-16bit)
-- **Homepage**: [16bitweather.co](https://16bitweather.co)
-- **Repository**: [GitHub](https://github.com/deephouse23/weather-cli)
-- **Issues**: [GitHub Issues](https://github.com/deephouse23/weather-cli/issues)
-- **API**: [OpenWeatherMap](https://openweathermap.org/api)
+- npm: [weather-cli-16bit](https://www.npmjs.com/package/weather-cli-16bit)
+- Repo: [github.com/deephouse23/weather-cli](https://github.com/deephouse23/weather-cli)
+- API: [openweathermap.org](https://openweathermap.org/api)

--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ import {
 import { WeatherError, mapErrorToExitCode } from './src/utils/errors.js';
 import { setApiKey, testApiKey } from './src/api/auth.js';
 import { parseLocation } from './src/utils/locationParser.js';
+import { runStatus } from './src/commands/status.js';
 
 dotenv.config({ quiet: true });
 
@@ -77,19 +78,22 @@ async function resolveLocation(provided) {
   throw new WeatherError('No location provided', 'INVALID_INPUT');
 }
 
+async function fetchWithCache(location, userUnits, { fetcher = getWeather } = {}) {
+  const cacheKey = userUnits || 'auto';
+  const cached = await getCachedWeather(location, cacheKey);
+  if (cached) {
+    console.log(chalk.gray('📦 Using cached data...'));
+    return cached;
+  }
+  const data = await fetcher(location, userUnits);
+  await setCachedWeather(location, cacheKey, data);
+  return data;
+}
+
 async function showCurrentWeather(location, options, { forecast = false } = {}) {
   const userUnits = processTemperatureOptions(options);
   const artOpts = await buildArtOptions(options);
-  const cacheKey = userUnits || 'auto';
-
-  let data = await getCachedWeather(location, cacheKey);
-  if (data) {
-    console.log(chalk.gray('📦 Using cached data...'));
-  } else {
-    data = await getWeather(location, userUnits);
-    await setCachedWeather(location, cacheKey, data);
-  }
-
+  const data = await fetchWithCache(location, userUnits);
   displayCurrentWeather(data, data.displayUnit, artOpts);
   if (forecast && !artOpts.artOnly) {
     display24HourForecast(data, data.displayUnit);
@@ -235,7 +239,7 @@ withArtOptions(
   const loc = await resolveLocation(location);
   const userUnits = processTemperatureOptions(options);
   const artOpts = await buildArtOptions(options);
-  const data = await getWeather(loc, userUnits);
+  const data = await fetchWithCache(loc, userUnits);
   displayCurrentWeather(data, data.displayUnit, artOpts);
   display24HourForecast(data, data.displayUnit);
 });
@@ -248,7 +252,7 @@ withArtOptions(
   const loc = await resolveLocation(location);
   const userUnits = processTemperatureOptions(options);
   const artOpts = await buildArtOptions(options);
-  const data = await getWeather(loc, userUnits);
+  const data = await fetchWithCache(loc, userUnits);
   displayCurrentWeather(data, data.displayUnit, artOpts);
   display5DayForecast(data, data.displayUnit);
 });
@@ -269,7 +273,9 @@ withArtOptions(
   const [lat, lon] = coordinates.split(',').map((c) => c.trim());
   const userUnits = processTemperatureOptions(options);
   const artOpts = await buildArtOptions(options);
-  const data = await getWeatherByCoords(lat, lon, userUnits);
+  const data = await fetchWithCache(`${lat},${lon}`, userUnits, {
+    fetcher: (_loc, units) => getWeatherByCoords(lat, lon, units)
+  });
   displayCurrentWeather(data, data.displayUnit, artOpts);
 });
 
@@ -365,6 +371,17 @@ program
       console.log(chalk.yellow(`  Expired entries: ${stats.expired}`));
     }
   });
+
+withUnitOptions(
+  program
+    .command('status [location...]')
+    .description('One-line weather output for shell prompts / tmux status bars (reads cache only)')
+    .option('--format <preset>', 'Output preset: default, compact, minimal', 'default')
+    .option('--no-emoji', 'Omit the weather icon')
+    .option('--refresh', 'Fetch fresh data if cache is empty or stale')
+).action(async (locationWords, options) => {
+  await runStatus(locationWords, options, { getDefaultLocation, processTemperatureOptions });
+});
 
 program
   .command('interactive')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "weather-cli-16bit",
-  "version": "0.3.62",
+  "version": "0.3.64",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "weather-cli-16bit",
-      "version": "0.3.62",
+      "version": "0.3.64",
       "license": "MIT",
       "os": [
         "darwin",
@@ -38,7 +38,7 @@
         "vitest": "^4.1.4"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weather-cli-16bit",
-  "version": "0.3.62",
+  "version": "0.3.64",
   "description": "A simple, intelligent weather CLI with smart location detection - no quotes needed",
   "main": "index.js",
   "type": "module",

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -1,0 +1,56 @@
+import chalk from 'chalk';
+import { getCachedWeather, setCachedWeather } from '../cache.js';
+import { getWeather } from '../weather.js';
+import { iconFor } from '../utils/icons.js';
+
+// Single-line output for shell prompts and tmux status bars.
+// Reads cache only by default; exits 1 when cache is empty so prompts can skip rendering.
+export async function runStatus(
+  locationWords,
+  options,
+  { getDefaultLocation, processTemperatureOptions }
+) {
+  const fromArgs = locationWords && locationWords.length > 0 ? locationWords.join(' ') : null;
+  const location = fromArgs || (await getDefaultLocation());
+  if (!location) {
+    if (options.refresh) {
+      process.stderr.write('No location provided and no default set\n');
+    }
+    process.exit(1);
+  }
+
+  const userUnits = processTemperatureOptions(options);
+  const cacheKey = userUnits || 'auto';
+
+  let data = await getCachedWeather(location, cacheKey);
+  if (!data) {
+    if (!options.refresh) process.exit(1);
+    data = await getWeather(location, userUnits);
+    await setCachedWeather(location, cacheKey, data);
+  }
+
+  process.stdout.write(formatStatus(data, options) + '\n');
+}
+
+export function formatStatus(data, options = {}) {
+  const weather = data.current || data;
+  const main = weather.weather?.[0]?.main;
+  const temp = Math.round(weather.main.temp);
+  const hi = Math.round(weather.main.temp_max);
+  const lo = Math.round(weather.main.temp_min);
+  const unit = data.displayUnit === 'fahrenheit' ? '°F' : '°C';
+  const icon = options.noEmoji ? '' : iconFor(main);
+  const name = weather.name;
+
+  const fmt = options.format || 'default';
+  if (fmt === 'minimal') {
+    return `${temp}${unit}`;
+  }
+  if (fmt === 'compact') {
+    return [icon, `${temp}${unit}`].filter(Boolean).join(' ');
+  }
+  // default
+  return [icon, name, chalk.bold(`${temp}${unit}`), chalk.dim(`↑${hi} ↓${lo}`)]
+    .filter(Boolean)
+    .join(' ');
+}

--- a/src/display.js
+++ b/src/display.js
@@ -2,18 +2,7 @@ import chalk from 'chalk';
 import boxen from 'boxen';
 import { getScene, isDaytime } from './ascii/index.js';
 import { AsciiRenderer } from './ascii/renderer.js';
-
-const weatherEmojis = {
-  Clear: '☀️',
-  Clouds: '☁️',
-  Rain: '🌧️',
-  Drizzle: '🌦️',
-  Thunderstorm: '⛈️',
-  Snow: '❄️',
-  Mist: '🌫️',
-  Fog: '🌫️',
-  Haze: '🌫️'
-};
+import { weatherEmojis } from './utils/icons.js';
 
 function formatTemp(temp, displayUnit, options = {}) {
   const unit = displayUnit === 'fahrenheit' ? '°F' : '°C';

--- a/src/utils/icons.js
+++ b/src/utils/icons.js
@@ -1,0 +1,15 @@
+export const weatherEmojis = {
+  Clear: '☀️',
+  Clouds: '☁️',
+  Rain: '🌧️',
+  Drizzle: '🌦️',
+  Thunderstorm: '⛈️',
+  Snow: '❄️',
+  Mist: '🌫️',
+  Fog: '🌫️',
+  Haze: '🌫️'
+};
+
+export function iconFor(main) {
+  return weatherEmojis[main] || '🌤️';
+}

--- a/tests/unit/status.test.js
+++ b/tests/unit/status.test.js
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { formatStatus } from '../../src/commands/status.js';
+
+const ANSI = /\x1b\[[0-9;]*m/g;
+const strip = (s) => s.replace(ANSI, '');
+
+const sampleData = {
+  current: {
+    name: 'San Ramon',
+    weather: [{ main: 'Clear' }],
+    main: { temp: 82.4, temp_min: 73.1, temp_max: 88.6 }
+  },
+  displayUnit: 'fahrenheit'
+};
+
+describe('formatStatus', () => {
+  it('default format includes icon, name, temp, hi/lo', () => {
+    const out = strip(formatStatus(sampleData));
+    expect(out).toContain('San Ramon');
+    expect(out).toContain('82°F');
+    expect(out).toContain('↑89');
+    expect(out).toContain('↓73');
+    expect(out).toContain('☀️');
+  });
+
+  it('compact format drops the name and hi/lo', () => {
+    const out = strip(formatStatus(sampleData, { format: 'compact' }));
+    expect(out).toBe('☀️ 82°F');
+  });
+
+  it('minimal format is temp only', () => {
+    const out = strip(formatStatus(sampleData, { format: 'minimal' }));
+    expect(out).toBe('82°F');
+  });
+
+  it('--no-emoji strips the icon in default format', () => {
+    const out = strip(formatStatus(sampleData, { noEmoji: true }));
+    expect(out).not.toContain('☀️');
+    expect(out).toContain('San Ramon');
+    expect(out.startsWith('San Ramon')).toBe(true);
+  });
+
+  it('handles celsius', () => {
+    const c = {
+      ...sampleData,
+      displayUnit: 'celsius',
+      current: { ...sampleData.current, main: { temp: 20.4, temp_min: 15, temp_max: 25 } }
+    };
+    const out = strip(formatStatus(c));
+    expect(out).toContain('20°C');
+  });
+
+  it('falls back to generic icon for unknown weather', () => {
+    const unknown = {
+      ...sampleData,
+      current: { ...sampleData.current, weather: [{ main: 'Tornado' }] }
+    };
+    const out = strip(formatStatus(unknown));
+    expect(out).toContain('🌤️');
+  });
+
+  it('reads data from root shape too (no nested .current)', () => {
+    const flat = {
+      name: 'London',
+      weather: [{ main: 'Rain' }],
+      main: { temp: 12, temp_min: 10, temp_max: 15 },
+      displayUnit: 'celsius'
+    };
+    const out = strip(formatStatus(flat));
+    expect(out).toContain('London');
+    expect(out).toContain('12°C');
+    expect(out).toContain('🌧️');
+  });
+});


### PR DESCRIPTION
## Summary

Two changes that make \`weather\` feel instant and fit into hardcore-CLI workflows without launching a separate TUI.

### #1 — Share the prefetched bundle across every command

\`_fetchWeatherData\` already hits three OpenWeatherMap endpoints in one call (current + 5day forecast + air pollution) and stores the full bundle, but only the default command and \`now\` were reading from cache. The \`forecast\`, \`5day\`, and \`coords\` subcommands re-fetched every time.

New \`fetchWithCache()\` helper in \`index.js\` — all four commands now share the same cache. After one \`weather London\`, any of \`weather forecast London\`, \`weather 5day London\`, or \`weather London\` again hits cache for the next 30 minutes.

### #2 — \`weather status\` for shell prompts and tmux

```
$ weather status
☀️ San Ramon 82°F ↑89 ↓73

$ weather status --format compact
☀️ 82°F

$ weather status --format minimal
82°F
```

Reads from cache only by default — no network, no spinner, no blocking the prompt. Exits \`1\` silently when cache is cold so starship / tmux skip rendering rather than paint stale junk. \`--refresh\` forces a fetch for one-off manual runs.

Starship config example:

\`\`\`toml
[custom.weather]
command = \"weather status --format compact\"
when = \"weather status --format compact\"
format = \"[\\$output](\\$style) \"
\`\`\`

tmux example in the README.

### Other
- Extracted \`weatherEmojis\` to \`src/utils/icons.js\` so \`status\` and \`display\` share one source of truth.
- Full README rewrite (the structural rewrite from #47 got lost in that merge — re-applying it, adding the new status section, noting the prefetch-once behavior).

## Test plan
- [x] \`npm test\` — 229/229 pass (7 new \`formatStatus\` tests)
- [x] \`npm run lint\` / \`format:check\` clean
- [x] \`weather status\` with cold cache exits 1 silently
- [x] \`weather status --help\` registers under root help
- [ ] Reviewer: run \`weather London\` then \`weather 5day London\` — second call should hit cache (shows \"📦 Using cached data...\")
- [ ] Reviewer: drop \`weather status --format compact\` into a starship custom module and confirm no prompt lag

🤖 Generated with [Claude Code](https://claude.com/claude-code)