### PR TITLE
fix: store config and cache outside the install directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ import {
 import { WeatherError, mapErrorToExitCode } from './src/utils/errors.js';
 import { setApiKey, testApiKey } from './src/api/auth.js';
 import { parseLocation } from './src/utils/locationParser.js';
+import { migrateLegacyFiles } from './src/utils/paths.js';
 import { runStatus } from './src/commands/status.js';
 
 dotenv.config({ quiet: true });
@@ -388,5 +389,7 @@ program
   .alias('i')
   .description('Interactive mode with prompts')
   .action(interactiveMode);
+
+await migrateLegacyFiles().catch(() => {});
 
 program.parseAsync().catch(handleError);

--- a/src/cache.js
+++ b/src/cache.js
@@ -1,12 +1,7 @@
 import fs from 'fs/promises';
-import { fileURLToPath } from 'url';
-import { dirname, join } from 'path';
+import { ensureParentDir, getCacheFile } from './utils/paths.js';
 import { WeatherError, ERROR_CODES } from './utils/errors.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-const CACHE_FILE = join(__dirname, '..', '.weather-cache.json');
 const CACHE_EXPIRY = 30 * 60 * 1000; // 30 minutes
 const MAX_CACHE_SIZE = 100; // Maximum number of entries
 const MAX_CACHE_AGE = 7 * 24 * 60 * 60 * 1000; // 7 days
@@ -17,7 +12,7 @@ const accessOrder = [];
 // Load cache from file
 async function loadCache() {
   try {
-    const data = await fs.readFile(CACHE_FILE, 'utf8');
+    const data = await fs.readFile(getCacheFile(), 'utf8');
     return JSON.parse(data);
   } catch {
     return {};
@@ -26,8 +21,10 @@ async function loadCache() {
 
 // Save cache to file
 async function saveCache(cache) {
+  const file = getCacheFile();
   try {
-    await fs.writeFile(CACHE_FILE, JSON.stringify(cache, null, 2));
+    await ensureParentDir(file);
+    await fs.writeFile(file, JSON.stringify(cache, null, 2));
   } catch (error) {
     throw new WeatherError('Failed to save cache', ERROR_CODES.CACHE_ERROR);
   }
@@ -149,7 +146,9 @@ async function getCacheStats() {
 
 // Clear all cache
 async function clearCache() {
-  await fs.writeFile(CACHE_FILE, '{}');
+  const file = getCacheFile();
+  await ensureParentDir(file);
+  await fs.writeFile(file, '{}');
 }
 
 export {

--- a/src/config.js
+++ b/src/config.js
@@ -1,16 +1,10 @@
 import fs from 'fs/promises';
-import { fileURLToPath } from 'url';
-import { dirname, join } from 'path';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-const CONFIG_FILE = join(__dirname, '..', '.weather-config.json');
+import { ensureParentDir, getConfigFile } from './utils/paths.js';
 
 // Load saved configuration
 async function loadConfig() {
   try {
-    const data = await fs.readFile(CONFIG_FILE, 'utf8');
+    const data = await fs.readFile(getConfigFile(), 'utf8');
     return JSON.parse(data);
   } catch {
     return {};
@@ -19,7 +13,9 @@ async function loadConfig() {
 
 // Save configuration
 async function saveConfig(config) {
-  await fs.writeFile(CONFIG_FILE, JSON.stringify(config, null, 2));
+  const file = getConfigFile();
+  await ensureParentDir(file);
+  await fs.writeFile(file, JSON.stringify(config, null, 2));
 }
 
 // Get default location

--- a/src/utils/paths.js
+++ b/src/utils/paths.js
@@ -1,0 +1,83 @@
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const APP_NAME = 'weather-cli';
+
+function joinHome(...segments) {
+  return path.join(os.homedir(), ...segments);
+}
+
+function getConfigDir() {
+  if (process.platform === 'win32') {
+    const appdata = process.env.APPDATA || joinHome('AppData', 'Roaming');
+    return path.join(appdata, APP_NAME);
+  }
+  const xdg = process.env.XDG_CONFIG_HOME;
+  return path.join(xdg || joinHome('.config'), APP_NAME);
+}
+
+function getCacheDir() {
+  if (process.platform === 'win32') {
+    const local = process.env.LOCALAPPDATA || joinHome('AppData', 'Local');
+    return path.join(local, APP_NAME);
+  }
+  const xdg = process.env.XDG_CACHE_HOME;
+  return path.join(xdg || joinHome('.cache'), APP_NAME);
+}
+
+export function getConfigFile() {
+  return path.join(getConfigDir(), 'config.json');
+}
+
+export function getCacheFile() {
+  return path.join(getCacheDir(), 'cache.json');
+}
+
+// Files written by older versions lived next to the installed package.
+// resolve() walks up two levels from src/utils/ to the package root.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PACKAGE_ROOT = path.resolve(__dirname, '..', '..');
+
+export function getLegacyConfigFile() {
+  return path.join(PACKAGE_ROOT, '.weather-config.json');
+}
+
+export function getLegacyCacheFile() {
+  return path.join(PACKAGE_ROOT, '.weather-cache.json');
+}
+
+export async function ensureParentDir(filePath) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+}
+
+async function migrateOne(legacyPath, newPath) {
+  try {
+    await fs.access(newPath);
+    return false;
+  } catch {
+    // new file does not exist yet, fall through to migration
+  }
+  let data;
+  try {
+    data = await fs.readFile(legacyPath, 'utf8');
+  } catch {
+    return false;
+  }
+  await ensureParentDir(newPath);
+  await fs.writeFile(newPath, data);
+  try {
+    await fs.unlink(legacyPath);
+  } catch {
+    // best-effort cleanup; ignore if we cannot remove the legacy file
+  }
+  return true;
+}
+
+export async function migrateLegacyFiles() {
+  await Promise.all([
+    migrateOne(getLegacyConfigFile(), getConfigFile()),
+    migrateOne(getLegacyCacheFile(), getCacheFile())
+  ]);
+}

--- a/tests/unit/cache.test.js
+++ b/tests/unit/cache.test.js
@@ -5,7 +5,8 @@ import fs from 'fs/promises';
 vi.mock('fs/promises', () => ({
   default: {
     readFile: vi.fn(),
-    writeFile: vi.fn()
+    writeFile: vi.fn(),
+    mkdir: vi.fn().mockResolvedValue(undefined)
   }
 }));
 

--- a/tests/unit/paths.test.js
+++ b/tests/unit/paths.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import os from 'os';
+import path from 'path';
+import { getConfigFile, getCacheFile } from '../../src/utils/paths.js';
+
+const ENV_KEYS = ['XDG_CONFIG_HOME', 'XDG_CACHE_HOME', 'APPDATA', 'LOCALAPPDATA'];
+
+describe('paths', () => {
+  let saved;
+
+  beforeEach(() => {
+    saved = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+    for (const k of ENV_KEYS) delete process.env[k];
+  });
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it('config file lives under the config dir, not the install dir', () => {
+    const file = getConfigFile();
+    expect(file).toContain('weather-cli');
+    expect(file.endsWith('config.json')).toBe(true);
+    expect(file).not.toMatch(/node_modules/);
+    if (process.platform !== 'win32') {
+      expect(file.startsWith(path.join(os.homedir(), '.config'))).toBe(true);
+    }
+  });
+
+  it('cache file lives under the cache dir, not the install dir', () => {
+    const file = getCacheFile();
+    expect(file).toContain('weather-cli');
+    expect(file.endsWith('cache.json')).toBe(true);
+    expect(file).not.toMatch(/node_modules/);
+    if (process.platform !== 'win32') {
+      expect(file.startsWith(path.join(os.homedir(), '.cache'))).toBe(true);
+    }
+  });
+
+  it('honors XDG_CONFIG_HOME when set (POSIX)', () => {
+    if (process.platform === 'win32') return;
+    process.env.XDG_CONFIG_HOME = '/tmp/xdg-config';
+    expect(getConfigFile()).toBe('/tmp/xdg-config/weather-cli/config.json');
+  });
+
+  it('honors XDG_CACHE_HOME when set (POSIX)', () => {
+    if (process.platform === 'win32') return;
+    process.env.XDG_CACHE_HOME = '/tmp/xdg-cache';
+    expect(getCacheFile()).toBe('/tmp/xdg-cache/weather-cli/cache.json');
+  });
+});


### PR DESCRIPTION
## Summary
- `.weather-config.json` and `.weather-cache.json` were being written next to the installed package via `__dirname/..`. For globally-installed users this either fails on permission-protected paths or gets wiped on `npm update`.
- Switch to XDG-style locations: `~/.config/weather-cli/config.json` and `~/.cache/weather-cli/cache.json` (with `XDG_CONFIG_HOME` / `XDG_CACHE_HOME` honored, and `%APPDATA%` / `%LOCALAPPDATA%` on Windows).
- New `src/utils/paths.js` centralizes path resolution, ensures parent directories exist on write, and migrates legacy files into the new locations on first run.

## Test plan
- [x] `npm test` — 233 passing (4 new tests in `paths.test.js`)
- [x] `npm run lint` — no new warnings
- [x] Smoke: `weather cache -c` creates `~/.cache/weather-cli/cache.json`
- [x] Smoke: legacy `.weather-config.json` / `.weather-cache.json` at the repo root get migrated and removed on first run, contents preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)