### PR TITLE
feat: render 24-hour forecast as a braille line chart

### DIFF
--- a/src/ascii/sparkline.js
+++ b/src/ascii/sparkline.js
@@ -1,0 +1,114 @@
+// Braille line-chart renderer.
+//
+// Each Unicode braille char (U+2800 + bits) packs a 2×4 dot grid, giving the
+// chart double the horizontal and quadruple the vertical resolution of the
+// surrounding text. We draw a polyline between consecutive data points using
+// Bresenham's line algorithm so slopes stay smooth.
+
+// Bit positions per (row, col) inside one braille cell.
+//   row 0:  ⠁ ⠈
+//   row 1:  ⠂ ⠐
+//   row 2:  ⠄ ⠠
+//   row 3:  ⡀ ⢀
+const BRAILLE_BITS = [
+  [0x01, 0x08],
+  [0x02, 0x10],
+  [0x04, 0x20],
+  [0x40, 0x80]
+];
+
+function brailleChar(bits) {
+  return String.fromCodePoint(0x2800 + bits);
+}
+
+function* bresenhamLine(x0, y0, x1, y1) {
+  const dx = Math.abs(x1 - x0);
+  const sx = x0 < x1 ? 1 : -1;
+  const dy = -Math.abs(y1 - y0);
+  const sy = y0 < y1 ? 1 : -1;
+  let err = dx + dy;
+  let x = x0;
+  let y = y0;
+  // Cap iterations as a safety belt against pathological inputs.
+  const maxSteps = dx - dy + 1;
+  for (let step = 0; step <= maxSteps; step++) {
+    yield [x, y];
+    if (x === x1 && y === y1) return;
+    const e2 = 2 * err;
+    if (e2 >= dy) {
+      err += dy;
+      x += sx;
+    }
+    if (e2 <= dx) {
+      err += dx;
+      y += sy;
+    }
+  }
+}
+
+// Render an array of numbers as a multi-row braille line chart.
+// width / height are in *character cells* — internally we work at 2×4 the
+// resolution to drive individual braille dots.
+export function renderBrailleLineChart(values, { width, height }) {
+  if (!Array.isArray(values) || values.length < 2 || width < 1 || height < 1) {
+    return '';
+  }
+
+  const dotW = width * 2;
+  const dotH = height * 4;
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1; // flat line when all values are equal
+
+  const points = values.map((v, i) => {
+    const x = Math.round((i / (values.length - 1)) * (dotW - 1));
+    // Higher value sits visually higher, which is a smaller y in our top-down grid.
+    const y = Math.round((1 - (v - min) / range) * (dotH - 1));
+    return [x, y];
+  });
+
+  const grid = Array.from({ length: height }, () => new Uint8Array(width));
+  const plot = (x, y) => {
+    if (x < 0 || x >= dotW || y < 0 || y >= dotH) return;
+    grid[Math.floor(y / 4)][Math.floor(x / 2)] |= BRAILLE_BITS[y % 4][x % 2];
+  };
+
+  for (let i = 0; i < points.length - 1; i++) {
+    const [x0, y0] = points[i];
+    const [x1, y1] = points[i + 1];
+    for (const [x, y] of bresenhamLine(x0, y0, x1, y1)) plot(x, y);
+  }
+
+  return grid.map((row) => Array.from(row, brailleChar).join('')).join('\n');
+}
+
+// Compute the integer column for each of `n` evenly-spaced points spanning
+// a chart of `width` columns. Always pins point 0 to col 0 and point n-1
+// to col width-1.
+export function dataPointColumns(n, width) {
+  if (n <= 0 || width <= 0) return [];
+  if (n === 1) return [0];
+  return Array.from({ length: n }, (_, i) => Math.round((i / (n - 1)) * (width - 1)));
+}
+
+// Lay out `items` at the given target column positions, separating with
+// spaces. If two items collide (target column already passed), the next
+// item is placed one space after the previous — better minor drift than
+// a thrown error.
+export function buildLabelRow(items, columns, itemWidths) {
+  let out = '';
+  let cursor = 0;
+  for (let i = 0; i < items.length; i++) {
+    const target = columns[i] ?? cursor;
+    if (target > cursor) {
+      out += ' '.repeat(target - cursor);
+      cursor = target;
+    } else if (i > 0) {
+      out += ' ';
+      cursor += 1;
+    }
+    out += items[i];
+    cursor += itemWidths[i] ?? 1;
+  }
+  return out;
+}

--- a/src/display.js
+++ b/src/display.js
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 import boxen from 'boxen';
 import { getScene, isDaytime } from './ascii/index.js';
 import { AsciiRenderer } from './ascii/renderer.js';
+import { renderBrailleLineChart, dataPointColumns, buildLabelRow } from './ascii/sparkline.js';
 import { weatherEmojis } from './utils/icons.js';
 
 function formatTemp(temp, displayUnit, options = {}) {
@@ -257,28 +258,107 @@ function display5DayForecast(data, displayUnit) {
   );
 }
 
+// Render the 24-hour forecast as a braille line chart with an emoji band
+// and time axis underneath. Falls back to a list view on terminals too narrow
+// to fit the chart cleanly (or when there isn't enough data to interpolate).
 function display24HourForecast(data, displayUnit) {
   const next24Hours = data.forecast.list.slice(0, 8);
+  if (next24Hours.length < 2) return; // nothing meaningful to chart
 
-  const forecastLines = next24Hours.map((item) => {
-    const time = new Date(item.dt * 1000).toLocaleTimeString('en-US', {
-      hour: 'numeric',
-      hour12: true
-    });
-    const emoji = weatherEmojis[item.weather[0].main] || '🌤️';
-    const temp = formatTemp(item.main.temp, displayUnit);
+  const termWidth = getTerminalWidth();
+  const boxWidth = Math.min(termWidth - 2, 88);
+  const innerWidth = boxWidth - 4; // accounts for boxen padding (left+right=2) + borders (1+1)
 
-    return `${time.padEnd(6)} ${emoji} ${temp.padEnd(6)} ${chalk.gray(item.weather[0].description)}`;
-  });
+  const renderedSpark = renderSparklineBlock(next24Hours, displayUnit, innerWidth);
+  const content = renderedSpark || renderForecastList(next24Hours, displayUnit);
 
   console.log(
-    boxen(forecastLines.join('\n'), {
+    boxen(content, {
+      title: chalk.bold('24-hour forecast'),
+      titleAlignment: 'left',
       padding: { top: 0, bottom: 0, left: 1, right: 1 },
       margin: 0,
       borderStyle: 'round',
-      borderColor: 'blue'
+      borderColor: 'blue',
+      width: boxWidth
     })
   );
+}
+
+function renderSparklineBlock(items, displayUnit, innerWidth) {
+  const temps = items.map((item) => item.main.temp);
+  const emojis = items.map((item) => weatherEmojis[item.weather[0].main] || '🌤️');
+  const times = items.map(
+    (item) =>
+      new Date(item.dt * 1000)
+        .toLocaleTimeString('en-US', { hour: 'numeric', hour12: true })
+        .replace(/\s/g, '')
+        .toLowerCase()
+        .replace(/m$/, '') // "12pm" → "12p", "9am" → "9a"
+  );
+
+  // Gutter on the left holds hi/lo °labels (e.g. "82°F  ").
+  const gutterText = '999°F  '; // worst-case width
+  const gutter = gutterText.length;
+
+  // 4 cells per data point is the readability floor (3-char time + 1 space).
+  const minStep = 4;
+  const maxStep = 10;
+  const availableForChart = innerWidth - gutter;
+  const stepFromAvail = Math.floor(availableForChart / items.length);
+  if (stepFromAvail < minStep) return null;
+
+  const step = Math.min(maxStep, stepFromAvail);
+  const chartWidth = step * (items.length - 1) + 1;
+  const chartHeight = 4;
+
+  const chart = renderBrailleLineChart(temps, { width: chartWidth, height: chartHeight });
+  if (!chart) return null;
+
+  const lines = chart.split('\n');
+  const hi = Math.max(...temps);
+  const lo = Math.min(...temps);
+  const hiLabel = formatTemp(hi, displayUnit, { colorCode: true, type: 'max' });
+  const loLabel = formatTemp(lo, displayUnit, { colorCode: true, type: 'min' });
+
+  // Top row gets the hi label, bottom row gets the lo label, others get pure padding.
+  const chartRows = lines.map((line, i) => {
+    let label = '';
+    if (i === 0) label = hiLabel;
+    else if (i === lines.length - 1) label = loLabel;
+    return padVisible(label, gutter) + chalk.cyan(line);
+  });
+
+  const cols = dataPointColumns(items.length, chartWidth);
+  // Treat each weather emoji as 2 cells (variation-selector emoji width is
+  // terminal-dependent but 2 is the dominant default in modern emulators).
+  const emojiRow =
+    ' '.repeat(gutter) + buildLabelRow(emojis, cols, new Array(items.length).fill(2));
+  const timeRow =
+    ' '.repeat(gutter) +
+    chalk.gray(
+      buildLabelRow(
+        times,
+        cols,
+        times.map((t) => t.length)
+      )
+    );
+
+  return [...chartRows, emojiRow, timeRow].join('\n');
+}
+
+function renderForecastList(items, displayUnit) {
+  return items
+    .map((item) => {
+      const time = new Date(item.dt * 1000).toLocaleTimeString('en-US', {
+        hour: 'numeric',
+        hour12: true
+      });
+      const emoji = weatherEmojis[item.weather[0].main] || '🌤️';
+      const temp = formatTemp(item.main.temp, displayUnit);
+      return `${time.padEnd(6)} ${emoji} ${temp.padEnd(6)} ${chalk.gray(item.weather[0].description)}`;
+    })
+    .join('\n');
 }
 
 export {

--- a/tests/unit/sparkline.test.js
+++ b/tests/unit/sparkline.test.js
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import {
+  renderBrailleLineChart,
+  dataPointColumns,
+  buildLabelRow
+} from '../../src/ascii/sparkline.js';
+
+const BRAILLE_BLANK = String.fromCodePoint(0x2800);
+
+describe('renderBrailleLineChart', () => {
+  it('returns empty string for too-few values', () => {
+    expect(renderBrailleLineChart([], { width: 10, height: 2 })).toBe('');
+    expect(renderBrailleLineChart([5], { width: 10, height: 2 })).toBe('');
+  });
+
+  it('returns the requested grid dimensions', () => {
+    const out = renderBrailleLineChart([1, 5, 3, 8, 2], { width: 16, height: 3 });
+    const lines = out.split('\n');
+    expect(lines).toHaveLength(3);
+    for (const line of lines) {
+      expect([...line]).toHaveLength(16);
+    }
+  });
+
+  it('renders only braille code points (U+2800..U+28FF)', () => {
+    const out = renderBrailleLineChart([10, 20, 5, 15], { width: 12, height: 3 });
+    for (const ch of out.replace(/\n/g, '')) {
+      const cp = ch.codePointAt(0);
+      expect(cp).toBeGreaterThanOrEqual(0x2800);
+      expect(cp).toBeLessThanOrEqual(0x28ff);
+    }
+  });
+
+  it('puts ink in the top row when the first value is the max', () => {
+    const out = renderBrailleLineChart([100, 50, 0], { width: 12, height: 4 });
+    const [topRow] = out.split('\n');
+    // First cell of the top row should have at least one set bit (not blank).
+    expect(topRow[0]).not.toBe(BRAILLE_BLANK);
+  });
+
+  it('puts ink in the bottom row when the last value is the min', () => {
+    const out = renderBrailleLineChart([100, 50, 0], { width: 12, height: 4 });
+    const rows = out.split('\n');
+    const lastRow = rows[rows.length - 1];
+    // Final cell of the last row should have at least one set bit.
+    expect(lastRow[lastRow.length - 1]).not.toBe(BRAILLE_BLANK);
+  });
+
+  it('handles a flat series without throwing', () => {
+    const out = renderBrailleLineChart([7, 7, 7, 7], { width: 8, height: 2 });
+    expect(out.split('\n')).toHaveLength(2);
+  });
+});
+
+describe('dataPointColumns', () => {
+  it('pins endpoints to col 0 and col width-1', () => {
+    const cols = dataPointColumns(5, 20);
+    expect(cols[0]).toBe(0);
+    expect(cols[cols.length - 1]).toBe(19);
+  });
+
+  it('returns evenly-spaced columns', () => {
+    const cols = dataPointColumns(5, 17);
+    expect(cols).toEqual([0, 4, 8, 12, 16]);
+  });
+
+  it('handles single-point input', () => {
+    expect(dataPointColumns(1, 10)).toEqual([0]);
+  });
+
+  it('handles zero/negative input', () => {
+    expect(dataPointColumns(0, 10)).toEqual([]);
+    expect(dataPointColumns(5, 0)).toEqual([]);
+  });
+});
+
+describe('buildLabelRow', () => {
+  it('pads to target columns with spaces', () => {
+    const row = buildLabelRow(['A', 'B', 'C'], [0, 5, 10], [1, 1, 1]);
+    expect(row).toBe('A    B    C');
+  });
+
+  it('falls back to a one-space separator when columns collide', () => {
+    // Columns are [0, 1, 5] but item widths exceed available space.
+    // The implementation must not crash and must keep all items visible.
+    const row = buildLabelRow(['HELLO', 'WORLD', 'X'], [0, 1, 5], [5, 5, 1]);
+    expect(row).toContain('HELLO');
+    expect(row).toContain('WORLD');
+    expect(row).toContain('X');
+  });
+
+  it('respects item widths when advancing the cursor', () => {
+    // Two two-cell-wide emojis with their target columns set 4 cells apart
+    // should render as: "EE  EE" (positions 0 and 4).
+    const row = buildLabelRow(['EE', 'EE'], [0, 4], [2, 2]);
+    expect(row).toBe('EE  EE');
+  });
+});


### PR DESCRIPTION
## Summary
- Replaces the eight-line text list in `weather forecast` with a multi-row braille line graph, an emoji band, and a time axis.
- Hi/lo temps live in the left gutter for at-a-glance scanning. Chart scales with terminal width down to a 4-cell-per-point minimum.
- New `src/ascii/sparkline.js` holds reusable chart primitives: `renderBrailleLineChart` (Bresenham polyline → 2x4 braille dots), `dataPointColumns` (data→column mapping), and `buildLabelRow` (emoji/time row layout).

### Before
```
9 PM   ☁️ 56°F   broken clouds
12 AM  ☁️ 54°F   overcast clouds
3 AM   ☁️ 53°F   overcast clouds
6 AM   ☁️ 53°F   overcast clouds
9 AM   ☁️ 56°F   broken clouds
12 PM  ⛅ 60°F   scattered clouds
3 PM   ☀️ 63°F   clear sky
6 PM   ☀️ 62°F   clear sky
```

### After
```
╭ 24-hour forecast ─────────────────────────────────╮
│ 64°F                       ⣀⠤⠔⠒⠊⠉⠉⠑⠒⠤⢄⣀⡀          │
│                       ⣀⠤⠒⠉              ⠈⠉⠒⠤⢄    │
│                  ⣀⣀⠤⠒⠉                          │
│ 52°F   ⠤⠤⠤⠤⠤⠤⠤⣀⣀⡠⠔⠊⠉                            │
│        🌫️  🌫️  ☁️  ☁️  ☁️  ☀️  ☀️  ☀️             │
│        9p  12a 3a  6a  9a  12p 3p  6p              │
╰────────────────────────────────────────────────────╯
```

## Test plan
- [x] `npm test` — 308 passing, 13 new tests in `tests/unit/sparkline.test.js`
- [x] `npm run lint` — no new warnings
- [x] Smoke: `weather forecast "San Francisco"` on an 80-col terminal renders the chart cleanly
- [x] Smoke: same command on a 50-col terminal still fits — min-step path keeps it readable
- [x] Sparkline module is independently testable (no chalk/boxen dependency) so it can power future visualizations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 24-hour forecast now displays as a visual line chart with temperature trends and time labels
  * Chart includes emoji weather indicators for quick scanning
  * Automatically falls back to list view on narrow terminals or with insufficient data

* **Tests**
  * Added comprehensive unit test coverage for new charting functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->