### PR TITLE
fix: harden HTTP client, sanitize error output, secure publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,20 +1,17 @@
-name: NPM Publish on PR Merge
+name: NPM Publish
 
 on:
-  pull_request:
-    types: [closed]
-    branches:
-      - main
-      - master
+  release:
+    types: [published]
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   publish:
-    # Only run if PR was merged, not just closed
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout code
@@ -36,14 +33,14 @@ jobs:
         env:
           CI: true
 
-      - name: Check if version changed
+      - name: Check if version matches release tag
         id: version_check
         run: |
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
-          NPM_VERSION=$(npm view weather-cli-16bit version 2>/dev/null || echo "0.0.0")
+          RELEASE_TAG="${GITHUB_REF#refs/tags/}"
           echo "package_version=$PACKAGE_VERSION" >> $GITHUB_OUTPUT
-          echo "npm_version=$NPM_VERSION" >> $GITHUB_OUTPUT
-          if [ "$PACKAGE_VERSION" != "$NPM_VERSION" ]; then
+          echo "release_tag=$RELEASE_TAG" >> $GITHUB_OUTPUT
+          if [ "v$PACKAGE_VERSION" = "$RELEASE_TAG" ]; then
             echo "should_publish=true" >> $GITHUB_OUTPUT
           else
             echo "should_publish=false" >> $GITHUB_OUTPUT
@@ -55,13 +52,3 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           CI: true
-
-      - name: Create GitHub Release
-        if: steps.version_check.outputs.should_publish == 'true'
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: v${{ steps.version_check.outputs.package_version }}
-          name: Release v${{ steps.version_check.outputs.package_version }}
-          generate_release_notes: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/api/http.js
+++ b/src/api/http.js
@@ -10,6 +10,9 @@ const packageJson = JSON.parse(readFileSync(join(__dirname, '..', '..', 'package
 
 const httpClient = axios.create({
   timeout: 5000,
+  maxRedirects: 0,
+  maxContentLength: 1024 * 1024,
+  maxBodyLength: 1024 * 1024,
   headers: {
     'User-Agent': `weather-cli/${packageJson.version}`
   }

--- a/src/api/openmeteo.js
+++ b/src/api/openmeteo.js
@@ -1,5 +1,6 @@
 import httpClient from './http.js';
 import { WeatherError, ERROR_CODES } from '../utils/errors.js';
+import { sanitizeForDisplay } from '../utils/validators.js';
 import { wmoToOwm, usAqiToOwmAqi } from './wmoToOwm.js';
 
 const GEOCODING_URL = 'https://geocoding-api.open-meteo.com/v1/search';
@@ -68,7 +69,7 @@ export async function geocode(input) {
   const results = res.data?.results || [];
   if (results.length === 0) {
     throw new WeatherError(
-      `Location "${input}" not found. Please check the spelling or try: "City, Country Code" (e.g., "San Ramon, US")`,
+      `Location "${sanitizeForDisplay(input)}" not found. Please check the spelling or try: "City, Country Code" (e.g., "San Ramon, US")`,
       ERROR_CODES.LOCATION_NOT_FOUND,
       404
     );

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -1,7 +1,17 @@
 import { WeatherError, ERROR_CODES } from './errors.js';
 
-const UNSAFE_CHARS_REGEX = /[<>'"{}|\\\^`]/g;
+const UNSAFE_CHARS_REGEX = /[<>'"{}|\\^`]/g;
+const ANSI_ESCAPE_REGEX = /\x1b\[[0-9;]*[a-zA-Z]/g;
 const MAX_LOCATION_LENGTH = 100;
+
+export function sanitizeForDisplay(str) {
+  if (typeof str !== 'string') return String(str);
+  return str
+    .replace(ANSI_ESCAPE_REGEX, '')
+    .replace(UNSAFE_CHARS_REGEX, '')
+    .trim()
+    .slice(0, MAX_LOCATION_LENGTH);
+}
 
 export function sanitizeLocation(location) {
   if (typeof location !== 'string') {

--- a/src/weather.js
+++ b/src/weather.js
@@ -1,6 +1,6 @@
 import ora from 'ora';
 import { WeatherError, ERROR_CODES } from './utils/errors.js';
-import { validateLocation, validateCoordinates } from './utils/validators.js';
+import { validateLocation, validateCoordinates, sanitizeForDisplay } from './utils/validators.js';
 import { geocode, fetchForecast, fetchAirQuality, normalizeToOwmShape } from './api/openmeteo.js';
 
 // Regional temperature units mapping (US + a handful of US-aligned territories)
@@ -47,11 +47,12 @@ function unitsForOpenMeteo(unitSystem) {
 }
 
 function rethrow(error, locationLabel) {
+  const safeLabel = sanitizeForDisplay(locationLabel);
   if (error instanceof WeatherError) return error;
 
   if (error.response?.status === 404) {
     return new WeatherError(
-      `Location "${locationLabel}" not found. Please check the spelling or try: "City, Country Code" (e.g., "San Ramon, US")`,
+      `Location "${safeLabel}" not found. Please check the spelling or try: "City, Country Code" (e.g., "San Ramon, US")`,
       ERROR_CODES.LOCATION_NOT_FOUND,
       404
     );


### PR DESCRIPTION
## Security Hardening — Pass 2 (Fix)

Addresses all findings from the security scan documented in `SECURITY_FINDINGS.md`.

### Changes

| ID | Severity | Fix |
|---|---|---|
| SEC-001 | HIGH | `.env` with API keys was in git history. This branch was created fresh from `main` — the history-rewrite approach is deferred. **Action required:** rotate the two exposed OWM API keys on openweathermap.org. |
| SEC-002 | HIGH | Switched `npm-publish.yml` from `pull_request: closed` trigger to `release: published`. Reduced top-level permissions to `contents: read` with job-level `contents: write`. Removed GitHub Release step. Version validated against release tag before publish. |
| SEC-003 | MEDIUM | Added `maxContentLength` and `maxBodyLength` (1 MB) to the axios client to prevent unbounded response bodies. |
| SEC-005/010 | LOW/MEDIUM | Added `sanitizeForDisplay()` to strip ANSI escapes, HTML-unsafe chars, and truncate to 100 chars before echoing user input in error messages. Applied in `openmeteo.js` and `weather.js`. |
| SEC-008 | INFO | Added `maxRedirects: 0` to the axios client to explicitly forbid HTTP redirects. |

### Gates
- `npm run format` — clean
- `npm run lint` — clean (2 pre-existing warnings, no new ones)
- `npm test` — 308/308 passing
- `./smoke-test.sh` — all checks pass