### PR TITLE
chore: remove dead code and unused dependencies

### DIFF
--- a/.hermes/plans/2026-05-30_dead-code-cleanup.md
+++ b/.hermes/plans/2026-05-30_dead-code-cleanup.md
@@ -1,0 +1,117 @@
+# Dead Code Cleanup Plan — weather-cli
+
+## Goal
+
+Remove dead code, unused exports, unused dependencies, and migration remnants from the weather-cli codebase. Reduce bundle size, improve maintainability, and eliminate confusion from OWM-era artifacts.
+
+## Audit Findings (organized by priority)
+
+### P0 — Definitely Dead (remove)
+
+1. **`formatWindDirection()` in `src/display.js` (~line 46)**
+   - Defined but never called anywhere. Wind display uses `degToArrow()` directly.
+   - Action: Delete the function entirely.
+
+2. **`setAsciiConfig()` in `src/config.js` (~line 88)**
+   - Exported but never imported outside tests. `index.js` writes ascii config inline.
+   - Action: Remove from exports. If tests need it, they can test via `saveConfig` + `loadConfig` or inline.
+
+3. **`@playwright/test` and `playwright` in `package.json` devDependencies**
+   - No E2E tests exist. No playwright config. Pure dead weight.
+   - Action: `npm uninstall @playwright/test playwright`
+
+4. **`husky` in `package.json` devDependencies**
+   - Listed but no `.husky/` directory and no git hooks configured. `lint-staged` runs via the `prepare` script but has no hook to trigger it.
+   - Action: Either set up husky properly OR remove it. Recommend removing — the CI already runs lint/format checks, and `lint-staged` runs via the pre-commit hook in `.pre-commit-config.yaml` (if configured). Check if `.pre-commit-config.yaml` references lint-staged.
+
+### P1 — Test-Only Exports (keep with `_` prefix or internalize)
+
+These exports are only imported by tests. Options: (A) keep as-is (it's fine for a CLI tool), (B) prefix with `_`, (C) move to a `test-helpers.js` file, (D) make them non-exported and test via integration.
+
+5. **`celsiusToFahrenheit()`, `fahrenheitToCelsius()`, `convertTemperature()` in `src/weather.js`**
+   - Only used in tests, not in production code.
+   - Action: These are reasonable test-only exports. Keep them — they're small utility functions with potential future use.
+
+6. **`loadCache()`, `saveCache()` in `src/cache.js`**
+   - Only used in tests, not production imports.
+   - Action: Keep — testing internal behavior requires these.
+
+7. **`loadConfig()`, `saveConfig()` in `src/config.js`**
+   - Only used in tests, not production imports.
+   - Action: Keep — same reasoning.
+
+8. **`formatTemp`, `formatTime`, `formatWindSpeed`, `formatVisibility`, `getAirQualityDescription`, `createDataRow` in `src/display.js`**
+   - All exported, only used internally or in tests.
+   - Action: Keep exports but they could be internal-only in a future refactor. Not urgent.
+
+### P2 — Architecture Remnants (informational, not removing)
+
+9. **OWM-shaped data structure throughout (`wmoToOwm.js`, `openmeteo.js`, `display.js`, `icons.js`)**
+   - The entire display layer uses `weather.main`, `weather.weather[0].main`, `weather.sys.sunrise` etc. — all OWM property names. `wmoToOwm.js` converts WMO codes into OWM code enums. `openmeteo.js` builds OWM-shaped response objects.
+   - This is a significant migration artifact but it WORKS. Refactoring to native Open-Meteo shapes would touch every file and every test.
+   - Action: None now. Flag for a future v1.0 refactor if desired.
+
+10. **`__resetForTesting()` exports in `src/config.js` and `src/cache.js`**
+    - Test-only helpers, appropriately named convention.
+    - Action: Keep. Standard pattern for testing stateful modules.
+
+11. **Naming: `usAqiToOwmAqi`, `wmoToOwm`, etc.**
+    - Functions still reference "OWM" in their names despite using Open-Meteo.
+    - Action: Low priority rename if desired in a future refactor. Not breaking anything.
+
+## Execution Plan
+
+### Step 1: Remove `formatWindDirection()`
+
+- File: `src/display.js`
+- Delete the function and its JSDoc
+- Verify no test references it (grep for `formatWindDirection`)
+
+### Step 2: Remove `setAsciiConfig()` from `src/config.js`
+
+- Delete the function
+- Remove from the `export` statement
+- Check tests — if any test imports it, update to use direct config manipulation
+
+### Step 3: Remove `@playwright/test` and `playwright`
+
+- Run: `npm uninstall @playwright/test playwright`
+- Verify `npm test` still passes
+
+### Step 4: Evaluate `husky`
+
+- Check `.pre-commit-config.yaml` for lint-staged integration
+- If no hooks configured, remove husky: `npm uninstall husky`
+- Also remove the `prepare` script referencing husky if removed
+
+### Step 5: Cleanup the `formatWindDirection` test
+
+- If `display.test.js` has tests for `formatWindDirection`, remove those too
+
+### Step 6: Run full gates
+
+- `npm run format`
+- `npm run lint`
+- `npm test`
+- `./smoke-test.sh`
+
+### Step 7: Commit, push, PR
+
+- Branch: `chore/dead-code-cleanup`
+- Conventional commit: `chore: remove dead code, unused deps`
+- Open PR immediately
+
+## Files Likely to Change
+
+- `src/display.js` — remove `formatWindDirection`
+- `src/config.js` — remove `setAsciiConfig`
+- `tests/unit/display.test.js` — remove tests for deleted function
+- `tests/unit/config.test.js` — remove tests for deleted function (if any)
+- `package.json` — remove playwright, possibly husky
+- `package-lock.json` — regenerated by npm uninstall
+
+## Risks / Open Questions
+
+- **OWM-shaped data**: Not removing it, just noting it. Future refactor opportunity.
+- **Test-only exports**: Keeping them. They don't bloat the bundle (tree-shaken in ESM) and they're useful for testing.
+- **husky**: Need to verify `.pre-commit-config.yaml` setup before removing.

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,12 +26,10 @@
         "weather": "bin/weather.js"
       },
       "devDependencies": {
-        "@playwright/test": "^1.59.1",
         "eslint": "^10.2.1",
         "eslint-config-prettier": "^10.1.8",
         "husky": "^9.1.7",
         "lint-staged": "^16.4.0",
-        "playwright": "^1.59.1",
         "prettier": "^3.8.3",
         "vitest": "^4.1.4"
       },
@@ -608,22 +606,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
-      }
-    },
-    "node_modules/@playwright/test": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright": "1.59.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -1955,21 +1937,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -2938,38 +2905,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright-core": "1.59.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -78,12 +78,10 @@
     "ora": "^9.3.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.59.1",
     "eslint": "^10.2.1",
     "eslint-config-prettier": "^10.1.8",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
-    "playwright": "^1.59.1",
     "prettier": "^3.8.3",
     "vitest": "^4.1.4"
   }

--- a/src/cache.js
+++ b/src/cache.js
@@ -44,7 +44,7 @@ async function saveCache(cache) {
   try {
     await fs.writeFile(tmpFile, JSON.stringify(cache, null, 2));
     await fs.rename(tmpFile, CACHE_FILE);
-  } catch (err) {
+  } catch {
     // Clean up the temp file if rename fails
     try {
       await fs.unlink(tmpFile);

--- a/src/config.js
+++ b/src/config.js
@@ -90,12 +90,6 @@ async function getAsciiConfig() {
   return config.ascii || { enabled: false, style: 'default' };
 }
 
-async function setAsciiConfig(asciiConfig) {
-  const config = await loadConfig();
-  config.ascii = { ...(config.ascii || {}), ...asciiConfig };
-  await saveConfig(config);
-}
-
 // Reset internal state between tests. Not for production use.
 function __resetForTesting() {
   _configDirEnsured = false;
@@ -110,6 +104,5 @@ export {
   setDefaultUnits,
   processTemperatureOptions,
   getAsciiConfig,
-  setAsciiConfig,
   __resetForTesting
 };

--- a/src/display.js
+++ b/src/display.js
@@ -27,26 +27,6 @@ function formatTime(timestamp) {
   });
 }
 
-function degToArrow(deg) {
-  // Normalize to 0-360
-  const d = ((deg % 360) + 360) % 360;
-  // 8 directions, each spanning 45°, centered on cardinal
-  const arrows = ['↑', '↗', '→', '↘', '↓', '↙', '←', '↖'];
-  const index = Math.round(d / 45) % 8;
-  return arrows[index];
-}
-
-function degToCardinal(deg) {
-  const d = ((deg % 360) + 360) % 360;
-  const cardinals = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW'];
-  const index = Math.round(d / 45) % 8;
-  return cardinals[index];
-}
-
-function formatWindDirection(deg) {
-  return `${degToArrow(deg)}${degToCardinal(deg)} (${deg}°)`;
-}
-
 function formatWindSpeed(speed, displayUnit, windUnit) {
   if (windUnit === 'mph') {
     // API already returned mph — no conversion needed

--- a/tests/unit/config.test.js
+++ b/tests/unit/config.test.js
@@ -27,7 +27,6 @@ const {
   setDefaultLocation,
   setDefaultUnits,
   getAsciiConfig,
-  setAsciiConfig,
   processTemperatureOptions,
   __resetForTesting
 } = configModule;
@@ -197,24 +196,6 @@ describe('getAsciiConfig', () => {
 
     const result = await getAsciiConfig();
     expect(result).toEqual({ enabled: false, style: 'default' });
-  });
-});
-
-describe('setAsciiConfig', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it('merges ascii config with existing values', async () => {
-    fs.readFile.mockResolvedValue(JSON.stringify({ ascii: { enabled: true, style: 'default' } }));
-    fs.writeFile.mockResolvedValue();
-    fs.rename.mockResolvedValue();
-
-    await setAsciiConfig({ style: 'retro' });
-
-    const writtenContent = fs.writeFile.mock.calls[0][1];
-    const parsed = JSON.parse(writtenContent);
-    expect(parsed.ascii).toEqual({ enabled: true, style: 'retro' });
   });
 });
 


### PR DESCRIPTION
## Dead Code Cleanup

Removes functions, tests, and dependencies that are never used in production code.

### Removed
- `formatWindDirection()` from `display.js` — defined but never called (wind display uses inline string)
- `degToCardinal()` from `display.js` — only called by the removed `formatWindDirection`
- `degToArrow()` from `display.js` — lint flagged as unused after removing its callers
- `setAsciiConfig()` from `config.js` — exported but never imported by production code (config command writes ascii config inline)
- `setAsciiConfig` test suite from `config.test.js`
- `@playwright/test` and `playwright` from devDependencies — no E2E tests exist
- Unused `err` catch binding in `cache.js` (lint warning)

### Kept (test-only exports)
These exports are only imported by tests but remain useful for testability:
- `celsiusToFahrenheit`, `fahrenheitToCelsius`, `convertTemperature` in `weather.js`
- `loadCache`, `saveCache` in `cache.js`
- `loadConfig`, `saveConfig` in `config.js`
- `formatTemp`, `formatTime`, `formatWindSpeed`, `formatVisibility`, `getAirQualityDescription`, `createDataRow` in `display.js`
- `__resetForTesting` in `config.js` and `cache.js`

### Noted (architectural remnant)
The codebase still uses OWM-shaped data structures internally (`weather.main`, `weather.weather[0].main`, etc.) despite migrating to Open-Meteo. The `wmoToOwm.js` compatibility layer makes this work seamlessly. Not removing — a future v1.0 refactor could align to Open-Meteo's native data shapes.

### Verification
- 307 tests passing
- Zero lint errors/warnings
- Format check clean
- Smoke test clean