### PR TITLE
refactor: codebase review fixes (P1-P3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ weather-cli is a Node.js command-line weather client powered by the Open-Meteo A
 - Vitest for testing
 - ESLint (flat config) + Prettier for linting/formatting
 - Pre-commit + Gitleaks for secret scanning and general hygiene
-- Husky + lint-staged is legacy and may coexist until migrated
+- Husky + lint-staged for pre-commit linting
 
 ## Repository Structure
 
@@ -20,8 +20,8 @@ weather-cli is a Node.js command-line weather client powered by the Open-Meteo A
 - `index.js` — CLI entry point (Commander program wiring)
 - `src/api/` — HTTP client, Open-Meteo adapter, WMO-to-OWM mapping
 - `src/ascii/` — ASCII art scenes and renderer
-- `src/cache.js` — JSON-file LRU cache (`.weather-cache.json`)
-- `src/config.js` — JSON-file user config (`.weather-config.json`)
+- `src/cache.js` — JSON-file LRU cache (`~/.cache/weather-cli/cache.json`)
+- `src/config.js` — JSON-file user config (`~/.config/weather-cli/config.json`)
 - `src/utils/` — errors, formatting, helpers
 - `tests/unit/` — Vitest unit tests
 - `.github/workflows/ci.yml` — CI (lint + format check + test matrix Node 20/22/24 + gitleaks)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ Single shared `axios` instance with 5 s timeout, `User-Agent: weather-cli/<versi
 
 ### Cache (src/cache.js)
 
-JSON file in the XDG cache directory: `~/.cache/weather-cli/cache.json` (or `$XDG_CACHE_HOME/weather-cli/cache.json`). 30-min entry expiry, 100-entry cap, 7-day hard max age, in-memory `accessOrder` array for LRU eviction. `accessOrder` is module-scoped so it's only meaningful within a single CLI invocation — across invocations LRU degrades to "first 100 surviving entries kept."
+JSON file in the XDG cache directory: `~/.cache/weather-cli/cache.json` (or `$XDG_CACHE_HOME/weather-cli/cache.json`). Entry expiry defaults to 30 min (configurable via `cacheTtl` in config), 100-entry cap, 7-day hard max age, and persisted `lastAccessed` timestamps to support LRU-style eviction across CLI invocations.
 
 Each cache entry carries a `schemaVersion` field. Bump `CACHE_SCHEMA_VERSION` in `src/cache.js` whenever the cached `data` shape changes — older entries are silently skipped on read. Current value: `3`.
 
@@ -73,7 +73,7 @@ Each cache entry carries a `schemaVersion` field. Bump `CACHE_SCHEMA_VERSION` in
 
 ### Config (src/config.js)
 
-JSON file in the XDG config directory: `~/.config/weather-cli/config.json` (or `$XDG_CONFIG_HOME/weather-cli/config.json`). Stores `defaultLocation`, `defaultUnits`, and `ascii: { enabled, style }`. `processTemperatureOptions()` is the single source of truth for resolving CLI flags into a unit string — call it instead of inspecting `options.celsius`/`options.fahrenheit`/`options.units` directly.
+JSON file in the XDG config directory: `~/.config/weather-cli/config.json` (or `$XDG_CONFIG_HOME/weather-cli/config.json`). Stores `defaultLocation`, `defaultUnits`, optional `cacheTtl`, and `ascii: { enabled, style }`. `processTemperatureOptions()` is the single source of truth for resolving CLI flags into a unit string — call it instead of inspecting `options.celsius`/`options.fahrenheit`/`options.units` directly.
 
 ## CI / publish flow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,9 +63,9 @@ Single shared `axios` instance with 5 s timeout, `User-Agent: weather-cli/<versi
 
 ### Cache (src/cache.js)
 
-JSON file at repo root: `.weather-cache.json`. 30-min entry expiry, 100-entry cap, 7-day hard max age, in-memory `accessOrder` array for LRU eviction. `accessOrder` is module-scoped so it's only meaningful within a single CLI invocation — across invocations LRU degrades to "first 100 surviving entries kept."
+JSON file in the XDG cache directory: `~/.cache/weather-cli/cache.json` (or `$XDG_CACHE_HOME/weather-cli/cache.json`). 30-min entry expiry, 100-entry cap, 7-day hard max age, in-memory `accessOrder` array for LRU eviction. `accessOrder` is module-scoped so it's only meaningful within a single CLI invocation — across invocations LRU degrades to "first 100 surviving entries kept."
 
-Each cache entry carries a `schemaVersion` field. Bump `CACHE_SCHEMA_VERSION` in `src/cache.js` whenever the cached `data` shape changes — older entries are silently skipped on read. Current value: `2` (post-Open-Meteo cutover).
+Each cache entry carries a `schemaVersion` field. Bump `CACHE_SCHEMA_VERSION` in `src/cache.js` whenever the cached `data` shape changes — older entries are silently skipped on read. Current value: `3`.
 
 ### ASCII art subsystem (src/ascii/)
 
@@ -73,7 +73,7 @@ Each cache entry carries a `schemaVersion` field. Bump `CACHE_SCHEMA_VERSION` in
 
 ### Config (src/config.js)
 
-JSON file at repo root: `.weather-config.json`. Stores `defaultLocation`, `defaultUnits`, and `ascii: { enabled, style }`. `processTemperatureOptions()` is the single source of truth for resolving CLI flags into a unit string — call it instead of inspecting `options.celsius`/`options.fahrenheit`/`options.units` directly.
+JSON file in the XDG config directory: `~/.config/weather-cli/config.json` (or `$XDG_CONFIG_HOME/weather-cli/config.json`). Stores `defaultLocation`, `defaultUnits`, and `ascii: { enabled, style }`. `processTemperatureOptions()` is the single source of truth for resolving CLI flags into a unit string — call it instead of inspecting `options.celsius`/`options.fahrenheit`/`options.units` directly.
 
 ## CI / publish flow
 
@@ -86,4 +86,3 @@ JSON file at repo root: `.weather-config.json`. Stores `defaultLocation`, `defau
 - Get `__dirname` via `dirname(fileURLToPath(import.meta.url))` — this pattern is reused across `index.js`, `cache.js`, `config.js`, and `http.js`.
 - Spinner pattern: create `ora('...').start()` inside the API call, `succeed`/`fail` it before returning/throwing.
 - Tests live in `tests/unit/*.test.js` (vitest config restricts to `tests/**/*.test.js`). `globals: true` is set, so `describe`/`it`/`expect` are available without import.
-- `tests/*.spec.js` files (`simple-weather-test.spec.js`, `weather-validation.spec.js`) are Playwright-style specs and **not** picked up by Vitest. There is a `playwright.config.{js,cjs}` but no `playwright` script in `package.json` — these aren't part of normal CI.

--- a/index.js
+++ b/index.js
@@ -27,6 +27,8 @@ import {
   getDefaultUnits,
   setDefaultLocation,
   setDefaultUnits,
+  getCacheTtl,
+  setCacheTtl,
   getAsciiConfig
 } from './src/config.js';
 import { WeatherError, mapErrorToExitCode } from './src/utils/errors.js';
@@ -103,8 +105,8 @@ async function compareWeather(city1, city2, options) {
   console.log(chalk.cyan.bold(`\n🌍 Comparing weather: ${city1} vs ${city2}`));
 
   const [data1, data2] = await Promise.all([
-    getWeather(city1, userUnits),
-    getWeather(city2, userUnits)
+    fetchWithCache(city1, userUnits),
+    fetchWithCache(city2, userUnits)
   ]);
 
   console.log(chalk.green('\n📍 City 1:'));
@@ -287,6 +289,7 @@ program
   .command('config')
   .description('Configure default settings')
   .action(async () => {
+    const currentTtl = await getCacheTtl();
     const answers = await inquirer.prompt([
       {
         type: 'input',
@@ -304,12 +307,26 @@ program
           { name: 'Fahrenheit (°F)', value: 'fahrenheit' }
         ],
         default: await getDefaultUnits()
+      },
+      {
+        type: 'input',
+        name: 'cacheTtl',
+        message: 'Cache TTL in minutes (1-1440, blank for default 30):',
+        default: currentTtl ? String(currentTtl) : '',
+        filter: (input) => {
+          const trimmed = input.trim();
+          if (!trimmed) return null;
+          const num = parseInt(trimmed, 10);
+          if (isNaN(num) || num < 1 || num > 1440) return null;
+          return num;
+        }
       }
     ]);
 
     await setDefaultLocation(answers.defaultLocation);
     await setDefaultUnits(answers.defaultUnits);
-    console.log(chalk.green('✅ Configuration saved!'));
+    await setCacheTtl(answers.cacheTtl);
+    console.log(chalk.green('Configuration saved!'));
   });
 
 program

--- a/index.js
+++ b/index.js
@@ -313,12 +313,18 @@ program
         name: 'cacheTtl',
         message: 'Cache TTL in minutes (1-1440, blank for default 30):',
         default: currentTtl ? String(currentTtl) : '',
+        validate: (input) => {
+          const trimmed = input.trim();
+          if (!trimmed) return true;
+          const num = Number.parseInt(trimmed, 10);
+          return Number.isInteger(num) && num >= 1 && num <= 1440
+            ? true
+            : 'Enter a number between 1 and 1440, or leave blank for default.';
+        },
         filter: (input) => {
           const trimmed = input.trim();
           if (!trimmed) return null;
-          const num = parseInt(trimmed, 10);
-          if (isNaN(num) || num < 1 || num > 1440) return null;
-          return num;
+          return Number.parseInt(trimmed, 10);
         }
       }
     ]);

--- a/src/api/openmeteo.js
+++ b/src/api/openmeteo.js
@@ -37,6 +37,80 @@ const COUNTRY_ALIASES = {
   HKG: 'HK'
 };
 
+// US state codes + DC — recognized as admin1 hints, not country codes.
+// Without this, "San Ramon, CA" would treat CA as country code "CA" (Canada)
+// instead of California, US.
+const US_STATE_CODES = new Set([
+  'AL',
+  'AK',
+  'AZ',
+  'AR',
+  'CA',
+  'CO',
+  'CT',
+  'DE',
+  'FL',
+  'GA',
+  'HI',
+  'ID',
+  'IL',
+  'IN',
+  'IA',
+  'KS',
+  'KY',
+  'LA',
+  'ME',
+  'MD',
+  'MA',
+  'MI',
+  'MN',
+  'MS',
+  'MO',
+  'MT',
+  'NE',
+  'NV',
+  'NH',
+  'NJ',
+  'NM',
+  'NY',
+  'NC',
+  'ND',
+  'OH',
+  'OK',
+  'OR',
+  'PA',
+  'RI',
+  'SC',
+  'SD',
+  'TN',
+  'TX',
+  'UT',
+  'VT',
+  'VA',
+  'WA',
+  'WV',
+  'WI',
+  'WY',
+  'DC'
+]);
+
+// Canadian province/territory codes — recognized as admin1 for country CA.
+const CA_PROVINCE_CODES = new Set([
+  'ON',
+  'QC',
+  'BC',
+  'AB',
+  'MB',
+  'SK',
+  'NS',
+  'NB',
+  'NL',
+  'PE',
+  'NT',
+  'YT',
+  'NU'
+]);
+
 export function parseLocationQuery(input) {
   const parts = input
     .split(',')
@@ -49,11 +123,23 @@ export function parseLocationQuery(input) {
 
   if (parts.length >= 2) {
     const last = parts[parts.length - 1].toUpperCase();
-    if (last.length <= 3 && /^[A-Z]+$/.test(last)) {
+
+    if (US_STATE_CODES.has(last)) {
+      // "San Ramon, CA" → state hint, country defaults to US
+      country = 'US';
+      admin1 = last;
+    } else if (CA_PROVINCE_CODES.has(last)) {
+      // "Vancouver, BC" → province hint, country is Canada
+      country = 'CA';
+      admin1 = last;
+    } else if (last.length <= 3 && /^[A-Z]+$/.test(last)) {
+      // Generic country code (2 or 3 letters), aliased if informal
       country = COUNTRY_ALIASES[last] || last;
     }
+    // If last part is longer than 3 chars, it's not a code — leave country/admin1 null
   }
-  if (parts.length >= 3) {
+  if (parts.length >= 3 && !admin1) {
+    // "City, State, Country" format — middle part is admin1 hint
     admin1 = parts[1].toUpperCase();
   }
 

--- a/src/api/openmeteo.js
+++ b/src/api/openmeteo.js
@@ -124,11 +124,11 @@ export function parseLocationQuery(input) {
   if (parts.length >= 2) {
     const last = parts[parts.length - 1].toUpperCase();
 
-    if (US_STATE_CODES.has(last)) {
+    if (parts.length === 2 && US_STATE_CODES.has(last)) {
       // "San Ramon, CA" → state hint, country defaults to US
       country = 'US';
       admin1 = last;
-    } else if (CA_PROVINCE_CODES.has(last)) {
+    } else if (parts.length === 2 && CA_PROVINCE_CODES.has(last)) {
       // "Vancouver, BC" → province hint, country is Canada
       country = 'CA';
       admin1 = last;
@@ -138,7 +138,7 @@ export function parseLocationQuery(input) {
     }
     // If last part is longer than 3 chars, it's not a code — leave country/admin1 null
   }
-  if (parts.length >= 3 && !admin1) {
+  if (parts.length >= 3) {
     // "City, State, Country" format — middle part is admin1 hint
     admin1 = parts[1].toUpperCase();
   }

--- a/src/ascii/scenes/cloudy.js
+++ b/src/ascii/scenes/cloudy.js
@@ -1,5 +1,6 @@
 // Cloudy animation frames - drifting clouds
-// 4 frames with subtle cloud movement (all within width 55)
+// 4 frames with cloud positions shifting left/right (all within width 55)
+// Frame 0 is the canonical static display (snapshot-tested).
 
 const cloudyFrame0 = [
   '            .-~~~-.                                  ',
@@ -17,14 +18,15 @@ const cloudyFrame0 = [
   '   |_________|___|__________|=|=|=|=|=|              '
 ];
 
+// Frame 1: top cloud shifts right, bottom cloud shifts left
 const cloudyFrame1 = [
-  '            .-~~~-.                                  ',
-  '      .- ~ ~-(       )- ~                            ',
-  '     /                     \\      .-~~~-.           ',
-  '    |                       |.- ~-(       )- ~       ',
-  '     \\                     /                  \\    ',
-  '       ~- . _____ . -~      \\                /     ',
-  '                               ~- . ___ . -~        ',
+  '             .-~~~-.                                 ',
+  '       .- ~ ~-(       )- ~                           ',
+  '      /                     \\     .-~~~-.           ',
+  '     |                       |.- ~-(       )- ~      ',
+  '      \\                     /                  \\   ',
+  '        ~- . _____ . -~      \\                /     ',
+  '                                ~- . ___ . -~        ',
   '           ( _ _._                                   ',
   "          |_|-'_~_`-._                              ",
   "       .-'-_~_-~_-~-_`-._                           ",
@@ -33,14 +35,15 @@ const cloudyFrame1 = [
   '   |_________|___|__________|=|=|=|=|=|              '
 ];
 
+// Frame 2: clouds shift further in same direction
 const cloudyFrame2 = [
-  '            .-~~~-.                                  ',
-  '      .- ~ ~-(       )- ~                            ',
-  '     /                     \\      .-~~~-.           ',
-  '    |                       |.- ~-(       )- ~       ',
-  '     \\                     /                  \\    ',
-  '       ~- . _____ . -~      \\                /     ',
-  '                               ~- . ___ . -~        ',
+  '              .-~~~-.                                ',
+  '        .- ~ ~-(       )- ~                          ',
+  '       /                     \\    .-~~~-.           ',
+  '      |                       |.- ~-(       )- ~     ',
+  '       \\                     /                  \\  ',
+  '         ~- . _____ . -~      \\                /     ',
+  '                                 ~- . ___ . -~        ',
   '           ( _ _._                                   ',
   "          |_|-'_~_`-._                              ",
   "       .-'-_~_-~_-~-_`-._                           ",
@@ -49,14 +52,15 @@ const cloudyFrame2 = [
   '   |_________|___|__________|=|=|=|=|=|              '
 ];
 
+// Frame 3: clouds drift back (slightly past center)
 const cloudyFrame3 = [
-  '            .-~~~-.                                  ',
-  '      .- ~ ~-(       )- ~                            ',
-  '     /                     \\      .-~~~-.           ',
-  '    |                       |.- ~-(       )- ~       ',
-  '     \\                     /                  \\    ',
-  '       ~- . _____ . -~      \\                /     ',
-  '                               ~- . ___ . -~        ',
+  '             .-~~~-.                                 ',
+  '       .- ~ ~-(       )- ~                           ',
+  '      /                     \\     .-~~~-.           ',
+  '     |                       |.- ~-(       )- ~      ',
+  '      \\                     /                  \\   ',
+  '        ~- . _____ . -~      \\                /     ',
+  '                                ~- . ___ . -~        ',
   '           ( _ _._                                   ',
   "          |_|-'_~_`-._                              ",
   "       .-'-_~_-~_-~-_`-._                           ",

--- a/src/ascii/scenes/sunny.js
+++ b/src/ascii/scenes/sunny.js
@@ -1,5 +1,6 @@
 // Sunny animation frames - pulsing sun rays
-// 4 frames with subtle ray movement (all within width 55)
+// 4 frames with ray rotation and subtle sun pulse (all within width 55)
+// Frame 0 is the canonical static display (snapshot-tested).
 
 const sunnyFrame0 = [
   '       \\   |   /                                    ',
@@ -17,12 +18,13 @@ const sunnyFrame0 = [
   '   |_________|___|__________|=|=|=|=|=|              '
 ];
 
+// Frame 1: rays swap direction (mirror), sun squints
 const sunnyFrame1 = [
-  '       \\   |   /                                    ',
+  '       /   |   \\                                    ',
   '        .---.                                        ',
-  '     --( o o )--                                     ',
+  '     --( - - )--                                     ',
   "        `---'            .-~~~-.                     ",
-  '       /   |   \\   .- ~ ~-(       )- ~              ',
+  '       \\   |   /   .- ~ ~-(       )- ~              ',
   '                   /                     \\           ',
   '                          ~                            ',
   '           ( _ _._                                   ',
@@ -33,12 +35,13 @@ const sunnyFrame1 = [
   '   |_________|___|__________|=|=|=|=|=|              '
 ];
 
+// Frame 2: rays spread wider, sun opens eyes
 const sunnyFrame2 = [
-  '       \\   |   /                                    ',
+  '      \\    |    /                                    ',
   '        .---.                                        ',
   '     --( o o )--                                     ',
   "        `---'            .-~~~-.                     ",
-  '       /   |   \\   .- ~ ~-(       )- ~              ',
+  '       /    |    \\   .- ~ ~-(       )- ~              ',
   '                   /                     \\           ',
   '                          ~                            ',
   '           ( _ _._                                   ',
@@ -49,12 +52,13 @@ const sunnyFrame2 = [
   '   |_________|___|__________|=|=|=|=|=|              '
 ];
 
+// Frame 3: rays swap back, sun squints again
 const sunnyFrame3 = [
-  '       \\   |   /                                    ',
+  '      /    |    \\                                    ',
   '        .---.                                        ',
-  '     --( o o )--                                     ',
+  '     --( - - )--                                     ',
   "        `---'            .-~~~-.                     ",
-  '       /   |   \\   .- ~ ~-(       )- ~              ',
+  '       \\    |    /   .- ~ ~-(       )- ~              ',
   '                   /                     \\           ',
   '                          ~                            ',
   '           ( _ _._                                   ',

--- a/src/cache.js
+++ b/src/cache.js
@@ -3,15 +3,36 @@ import { randomUUID } from 'crypto';
 import { join } from 'path';
 import { homedir } from 'os';
 import { WeatherError, ERROR_CODES } from './utils/errors.js';
+import { loadConfig } from './config.js';
 
 const XDG_CACHE_HOME = process.env.XDG_CACHE_HOME || join(homedir(), '.cache');
 const CACHE_DIR = join(XDG_CACHE_HOME, 'weather-cli');
 const CACHE_FILE = join(CACHE_DIR, 'cache.json');
-const CACHE_EXPIRY = 30 * 60 * 1000; // 30 minutes
+const DEFAULT_CACHE_EXPIRY = 30 * 60 * 1000; // 30 minutes
 const MAX_CACHE_SIZE = 100; // Maximum number of entries
 const MAX_CACHE_AGE = 7 * 24 * 60 * 60 * 1000; // 7 days
 // Bump when the cached `data` shape changes. Old entries are discarded on read.
 const CACHE_SCHEMA_VERSION = 3;
+
+// Resolve the effective cache TTL from config, falling back to the default.
+// Config value `cacheTtl` is in minutes. Clamped to [1, 1440] (1 min to 24h).
+// Memoized per CLI invocation since config doesn't change mid-run.
+let _cachedExpiry = null;
+async function getCacheExpiry() {
+  if (_cachedExpiry !== null) return _cachedExpiry;
+  try {
+    const config = await loadConfig();
+    const ttlMinutes = config.cacheTtl;
+    if (typeof ttlMinutes === 'number' && ttlMinutes >= 1 && ttlMinutes <= 1440) {
+      _cachedExpiry = ttlMinutes * 60 * 1000;
+    } else {
+      _cachedExpiry = DEFAULT_CACHE_EXPIRY;
+    }
+  } catch {
+    _cachedExpiry = DEFAULT_CACHE_EXPIRY;
+  }
+  return _cachedExpiry;
+}
 
 // Ensure the cache directory exists before any file I/O.
 // Called lazily on first read/write so we don't create dirs for mere imports.
@@ -98,25 +119,38 @@ function evictOldEntries(cache) {
   return Object.fromEntries(fresh);
 }
 
+// Minimum time between lastAccessed updates on cache reads.
+// Without this, every cache hit (e.g. `weather status` in a tmux bar running
+// every minute) triggers an atomic file write. 5 min is frequent enough for
+// LRU eviction to work well, while reducing disk I/O by ~80% for status-bar
+// integrations.
+const LAST_ACCESSED_UPDATE_THRESHOLD = 5 * 60 * 1000; // 5 minutes
+
 // Get cached weather data if not expired and schema matches.
 // On a cache hit, records the access time so LRU eviction works
 // across CLI invocations (not just within one process).
+// Only writes lastAccessed if the existing value is older than the threshold
+// to avoid excessive disk I/O on frequent cache reads.
 async function getCachedWeather(location, units) {
   const key = `${location}-${units}`;
+  const expiry = await getCacheExpiry();
 
-  // Use merge-and-save so we don't clobber concurrent writes while
-  // updating lastAccessed.
   let hitData = null;
+
   await mergeAndSaveCache((diskCache) => {
     const cached = diskCache[key];
     if (
       cached &&
       cached.schemaVersion === CACHE_SCHEMA_VERSION &&
-      Date.now() - cached.timestamp < CACHE_EXPIRY
+      Date.now() - cached.timestamp < expiry
     ) {
-      // Record the access so eviction can sort by recency
       hitData = cached.data;
-      diskCache[key] = { ...cached, lastAccessed: Date.now() };
+      const now = Date.now();
+      const lastAccessed = cached.lastAccessed ?? cached.timestamp;
+      // Only update lastAccessed if it's stale enough to warrant a write
+      if (now - lastAccessed >= LAST_ACCESSED_UPDATE_THRESHOLD) {
+        diskCache[key] = { ...cached, lastAccessed: now };
+      }
     }
     return diskCache;
   });
@@ -145,12 +179,13 @@ async function setCachedWeather(location, units, data) {
 // Clean expired cache entries
 async function cleanExpiredCache() {
   let cleaned = 0;
+  const expiry = await getCacheExpiry();
 
   await mergeAndSaveCache((diskCache) => {
     const now = Date.now();
     const result = {};
     for (const [key, value] of Object.entries(diskCache)) {
-      if (now - value.timestamp >= CACHE_EXPIRY) {
+      if (now - value.timestamp >= expiry) {
         cleaned++;
       } else {
         result[key] = value;
@@ -170,13 +205,14 @@ async function cleanExpiredCache() {
 async function getCacheStats() {
   const cache = await loadCache();
   const now = Date.now();
+  const expiry = await getCacheExpiry();
   let total = 0;
   let expired = 0;
   let valid = 0;
 
   for (const value of Object.values(cache)) {
     total++;
-    if (now - value.timestamp >= CACHE_EXPIRY) {
+    if (now - value.timestamp >= expiry) {
       expired++;
     } else {
       valid++;
@@ -194,6 +230,7 @@ async function clearCache() {
 // Reset internal state between tests. Not for production use.
 function __resetForTesting() {
   _cacheDirEnsured = false;
+  _cachedExpiry = null;
 }
 
 export {

--- a/src/cache.js
+++ b/src/cache.js
@@ -135,25 +135,34 @@ async function getCachedWeather(location, units) {
   const key = `${location}-${units}`;
   const expiry = await getCacheExpiry();
 
-  let hitData = null;
+  // Read-only path: check cache without writing.
+  // We only trigger a write (to update lastAccessed) if the threshold has
+  // been exceeded, avoiding unnecessary disk I/O on every cache hit.
+  const diskCache = await loadCache();
+  const cached = diskCache[key];
+  if (
+    !cached ||
+    cached.schemaVersion !== CACHE_SCHEMA_VERSION ||
+    Date.now() - cached.timestamp >= expiry
+  ) {
+    return null;
+  }
 
-  await mergeAndSaveCache((diskCache) => {
-    const cached = diskCache[key];
-    if (
-      cached &&
-      cached.schemaVersion === CACHE_SCHEMA_VERSION &&
-      Date.now() - cached.timestamp < expiry
-    ) {
-      hitData = cached.data;
-      const now = Date.now();
-      const lastAccessed = cached.lastAccessed ?? cached.timestamp;
-      // Only update lastAccessed if it's stale enough to warrant a write
-      if (now - lastAccessed >= LAST_ACCESSED_UPDATE_THRESHOLD) {
-        diskCache[key] = { ...cached, lastAccessed: now };
+  const hitData = cached.data;
+
+  // Only write if lastAccessed is stale enough to warrant it
+  const now = Date.now();
+  const lastAccessed = cached.lastAccessed ?? cached.timestamp;
+  if (now - lastAccessed >= LAST_ACCESSED_UPDATE_THRESHOLD) {
+    await mergeAndSaveCache((dc) => {
+      // Re-read from disk inside merge to pick up concurrent writes
+      const entry = dc[key];
+      if (entry) {
+        dc[key] = { ...entry, lastAccessed: now };
       }
-    }
-    return diskCache;
-  });
+      return dc;
+    });
+  }
 
   return hitData;
 }

--- a/src/config.js
+++ b/src/config.js
@@ -75,6 +75,23 @@ async function setDefaultUnits(units) {
   await saveConfig(config);
 }
 
+// Get configurable cache TTL (in minutes). Returns null if not set.
+async function getCacheTtl() {
+  const config = await loadConfig();
+  return config.cacheTtl ?? null;
+}
+
+// Set configurable cache TTL (in minutes). Pass null to reset to default.
+async function setCacheTtl(minutes) {
+  const config = await loadConfig();
+  if (minutes === null) {
+    delete config.cacheTtl;
+  } else {
+    config.cacheTtl = minutes;
+  }
+  await saveConfig(config);
+}
+
 // Process temperature options from command line
 function processTemperatureOptions(options) {
   if (options.celsius) return 'celsius';
@@ -102,6 +119,8 @@ export {
   getDefaultUnits,
   setDefaultLocation,
   setDefaultUnits,
+  getCacheTtl,
+  setCacheTtl,
   processTemperatureOptions,
   getAsciiConfig,
   __resetForTesting

--- a/src/utils/locationParser.js
+++ b/src/utils/locationParser.js
@@ -1,131 +1,12 @@
-export const STATE_MAPPINGS = {
-  // US States
-  AL: 'Alabama, US',
-  AK: 'Alaska, US',
-  AZ: 'Arizona, US',
-  AR: 'Arkansas, US',
-  CA: 'California, US',
-  CO: 'Colorado, US',
-  CT: 'Connecticut, US',
-  DE: 'Delaware, US',
-  FL: 'Florida, US',
-  GA: 'Georgia, US',
-  HI: 'Hawaii, US',
-  ID: 'Idaho, US',
-  IL: 'Illinois, US',
-  IN: 'Indiana, US',
-  IA: 'Iowa, US',
-  KS: 'Kansas, US',
-  KY: 'Kentucky, US',
-  LA: 'Louisiana, US',
-  ME: 'Maine, US',
-  MD: 'Maryland, US',
-  MA: 'Massachusetts, US',
-  MI: 'Michigan, US',
-  MN: 'Minnesota, US',
-  MS: 'Mississippi, US',
-  MO: 'Missouri, US',
-  MT: 'Montana, US',
-  NE: 'Nebraska, US',
-  NV: 'Nevada, US',
-  NH: 'New Hampshire, US',
-  NJ: 'New Jersey, US',
-  NM: 'New Mexico, US',
-  NY: 'New York, US',
-  NC: 'North Carolina, US',
-  ND: 'North Dakota, US',
-  OH: 'Ohio, US',
-  OK: 'Oklahoma, US',
-  OR: 'Oregon, US',
-  PA: 'Pennsylvania, US',
-  RI: 'Rhode Island, US',
-  SC: 'South Carolina, US',
-  SD: 'South Dakota, US',
-  TN: 'Tennessee, US',
-  TX: 'Texas, US',
-  UT: 'Utah, US',
-  VT: 'Vermont, US',
-  VA: 'Virginia, US',
-  WA: 'Washington, US',
-  WV: 'West Virginia, US',
-  WI: 'Wisconsin, US',
-  WY: 'Wyoming, US',
-  DC: 'Washington DC, US',
-
-  // Canadian Provinces
-  ON: 'Ontario, CA',
-  QC: 'Quebec, CA',
-  BC: 'British Columbia, CA',
-  AB: 'Alberta, CA',
-  MB: 'Manitoba, CA',
-  SK: 'Saskatchewan, CA',
-  NS: 'Nova Scotia, CA',
-  NB: 'New Brunswick, CA',
-  NL: 'Newfoundland, CA',
-  PE: 'Prince Edward Island, CA',
-  NT: 'Northwest Territories, CA',
-  YT: 'Yukon, CA',
-  NU: 'Nunavut, CA',
-
-  // Country Codes
-  USA: 'United States',
-  UK: 'United Kingdom',
-  UAE: 'United Arab Emirates',
-  JP: 'Japan',
-  FR: 'France',
-  DE: 'Germany',
-  AU: 'Australia',
-  NZ: 'New Zealand',
-  IT: 'Italy',
-  ES: 'Spain',
-  MX: 'Mexico',
-  BR: 'Brazil',
-  IN: 'India',
-  CN: 'China'
-};
-
-export const MAJOR_CITIES = {
-  // US Cities
-  'san francisco': 'San Francisco, CA, US',
-  'los angeles': 'Los Angeles, CA, US',
-  'san diego': 'San Diego, CA, US',
-  'san jose': 'San Jose, CA, US',
-  'san ramon': 'San Ramon, CA, US',
-  'new york': 'New York, NY, US',
-  chicago: 'Chicago, IL, US',
-  houston: 'Houston, TX, US',
-  phoenix: 'Phoenix, AZ, US',
-  philadelphia: 'Philadelphia, PA, US',
-  'san antonio': 'San Antonio, TX, US',
-  dallas: 'Dallas, TX, US',
-  austin: 'Austin, TX, US',
-  seattle: 'Seattle, WA, US',
-  boston: 'Boston, MA, US',
-  miami: 'Miami, FL, US',
-
-  // International Cities
-  london: 'London, UK',
-  paris: 'Paris, FR',
-  tokyo: 'Tokyo, JP',
-  sydney: 'Sydney, AU',
-  toronto: 'Toronto, CA',
-  vancouver: 'Vancouver, CA',
-  berlin: 'Berlin, DE',
-  madrid: 'Madrid, ES',
-  rome: 'Rome, IT',
-  amsterdam: 'Amsterdam, NL',
-  dubai: 'Dubai, AE',
-  singapore: 'Singapore, SG',
-  'hong kong': 'Hong Kong, HK',
-  mumbai: 'Mumbai, IN',
-  beijing: 'Beijing, CN',
-  shanghai: 'Shanghai, CN'
-};
+// Parse variadic CLI location words into a single location string.
+// Handles: option filtering (flags, unit keywords), comma normalization.
+// Does NOT expand state/country codes or hardcode cities — the Open-Meteo
+// geocoding API resolves all of that via parseLocationQuery in src/api/openmeteo.js.
 
 export function parseLocation(args) {
   if (!args || args.length === 0) return null;
 
-  // Join all arguments, filtering out options
+  // Join all arguments, filtering out CLI flags and unit keywords
   const locationArgs = args.filter(
     (arg) =>
       !arg.startsWith('-') && !['metric', 'imperial', 'celsius', 'fahrenheit', 'auto'].includes(arg)
@@ -134,42 +15,10 @@ export function parseLocation(args) {
   if (locationArgs.length === 0) return null;
 
   let location = locationArgs.join(' ').trim();
+  if (!location) return null;
 
-  // Check for state/country mapping (single argument like "CA")
-  const upperLocation = location.toUpperCase();
-  if (STATE_MAPPINGS[upperLocation]) {
-    return STATE_MAPPINGS[upperLocation];
-  }
-
-  // Check for known city
-  const lowerLocation = location.toLowerCase();
-  if (MAJOR_CITIES[lowerLocation]) {
-    return MAJOR_CITIES[lowerLocation];
-  }
-
-  // Intelligent parsing for "City State" format
-  const parts = location.split(/\s+/);
-  if (parts.length >= 2) {
-    const lastPart = parts[parts.length - 1].toUpperCase();
-
-    // Check if last part is a state/country code
-    if (STATE_MAPPINGS[lastPart]) {
-      const cityParts = parts.slice(0, -1).join(' ');
-      const mappedValue = STATE_MAPPINGS[lastPart];
-      const countryCode = mappedValue.includes(', ') ? mappedValue.split(', ').pop() : 'US';
-      return `${cityParts}, ${lastPart}, ${countryCode}`;
-    }
-
-    // Check if it's a 2-3 letter code (likely state/country)
-    if (lastPart.length <= 3 && /^[A-Z]+$/.test(lastPart)) {
-      const cityParts = parts.slice(0, -1).join(' ');
-      return `${cityParts}, ${lastPart}`;
-    }
-  }
-
-  // Handle formats with existing commas
+  // Normalize spacing around commas: "City,State" -> "City, State"
   if (location.includes(',')) {
-    // Clean up spacing around commas
     location = location.replace(/\s*,\s*/g, ', ');
   }
 

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -28,75 +28,11 @@ export function validateLocation(location) {
     throw new WeatherError('Location cannot be empty', ERROR_CODES.INVALID_INPUT);
   }
 
-  // Allow locations with or without commas
-  // If it has a comma, ensure state/country code is 2 letters
-  if (sanitized.includes(',')) {
-    const parts = sanitized.split(',').map((p) => p.trim());
-    if (parts.length === 2) {
-      const [city, stateOrCountry] = parts;
-      // Convert state codes to country codes for OpenWeatherMap
-      // CA (California) -> US, etc.
-      const stateToCountry = {
-        AL: 'US',
-        AK: 'US',
-        AZ: 'US',
-        AR: 'US',
-        CA: 'US',
-        CO: 'US',
-        CT: 'US',
-        DE: 'US',
-        FL: 'US',
-        GA: 'US',
-        HI: 'US',
-        ID: 'US',
-        IL: 'US',
-        IN: 'US',
-        IA: 'US',
-        KS: 'US',
-        KY: 'US',
-        LA: 'US',
-        ME: 'US',
-        MD: 'US',
-        MA: 'US',
-        MI: 'US',
-        MN: 'US',
-        MS: 'US',
-        MO: 'US',
-        MT: 'US',
-        NE: 'US',
-        NV: 'US',
-        NH: 'US',
-        NJ: 'US',
-        NM: 'US',
-        NY: 'US',
-        NC: 'US',
-        ND: 'US',
-        OH: 'US',
-        OK: 'US',
-        OR: 'US',
-        PA: 'US',
-        RI: 'US',
-        SC: 'US',
-        SD: 'US',
-        TN: 'US',
-        TX: 'US',
-        UT: 'US',
-        VT: 'US',
-        VA: 'US',
-        WA: 'US',
-        WV: 'US',
-        WI: 'US',
-        WY: 'US'
-      };
-
-      const upperStateOrCountry = stateOrCountry.toUpperCase();
-      if (stateToCountry[upperStateOrCountry]) {
-        // It's a US state code, convert to country format
-        return `${city}, ${stateToCountry[upperStateOrCountry]}`;
-      }
-    }
-  }
-
+  // Pass the location through as-is. State/country code parsing is handled
+  // by parseLocationQuery in src/api/openmeteo.js, which uses the codes as
+  // admin1/country hints for the Open-Meteo geocoding API. Rewriting here
+  // (e.g. "San Ramon, CA" -> "San Ramon, US") would strip the state-level
+  // disambiguation that geocode() relies on.
   return sanitized;
 }
 

--- a/tests/unit/ascii/scenes.test.js
+++ b/tests/unit/ascii/scenes.test.js
@@ -82,3 +82,31 @@ for (const { module: scene, label } of scenes) {
     });
   });
 }
+
+// Verify that animated scenes actually have differing frames.
+// A scene with frameCount > 1 but identical frames is a no-op animation.
+describe('animation frame differences', () => {
+  const animatedScenes = [
+    { module: sunny, label: 'sunny' },
+    { module: cloudy, label: 'cloudy' },
+    { module: rain, label: 'rain' },
+    { module: snow, label: 'snow' },
+    { module: thunder, label: 'thunder' },
+    { module: fog, label: 'fog' },
+    { module: nightClear, label: 'night-clear' }
+  ];
+
+  for (const { module: scene, label } of animatedScenes) {
+    if (!scene.frameCount || scene.frameCount < 2) continue;
+
+    it(`${label}: at least one frame differs from frame 0`, () => {
+      const frames = scene.getFrames();
+      const frame0Json = JSON.stringify(frames[0]);
+      const anyDifferent = frames.slice(1).some((f) => JSON.stringify(f) !== frame0Json);
+      expect(
+        anyDifferent,
+        `${label} has ${scene.frameCount} frames but they are all identical`
+      ).toBe(true);
+    });
+  }
+});

--- a/tests/unit/cache.test.js
+++ b/tests/unit/cache.test.js
@@ -17,6 +17,13 @@ vi.mock('crypto', () => ({
   randomUUID: () => 'test-uuid'
 }));
 
+// Mock config so cache.js's getCacheExpiry() gets a deterministic empty config.
+// Without this, loadConfig would try to read the config file via the mocked
+// fs/promises and get whatever data the cache test set up for readFile.
+vi.mock('../../src/config.js', () => ({
+  loadConfig: vi.fn().mockResolvedValue({})
+}));
+
 // Import after mocking
 const cacheModule = await import('../../src/cache.js');
 const {
@@ -438,13 +445,13 @@ describe('LRU eviction across invocations', () => {
     expect(parsed['NewCity-auto']).toBeDefined();
   });
 
-  it('getCachedWeather records lastAccessed on cache hit', async () => {
+  it('getCachedWeather records lastAccessed on cache hit when stale', async () => {
     const now = Date.now();
     const cachedData = {
       'London-auto': {
         data: { current: { temp: 20 } },
-        timestamp: now - 5 * 60 * 1000,
-        lastAccessed: now - 5 * 60 * 1000, // initially set at insertion time
+        timestamp: now - 10 * 60 * 1000,
+        lastAccessed: now - 10 * 60 * 1000, // 10 min ago — past the 5-min threshold
         schemaVersion: 3
       }
     };
@@ -461,6 +468,30 @@ describe('LRU eviction across invocations', () => {
     const writtenContent = fs.writeFile.mock.calls[0][1];
     const parsed = JSON.parse(writtenContent);
     expect(parsed['London-auto'].lastAccessed).toBeGreaterThanOrEqual(before);
+  });
+
+  it('getCachedWeather skips lastAccessed write when recently accessed', async () => {
+    const now = Date.now();
+    const cachedData = {
+      'London-auto': {
+        data: { current: { temp: 20 } },
+        timestamp: now - 10 * 60 * 1000,
+        lastAccessed: now - 1 * 60 * 1000, // 1 min ago — within the 5-min threshold
+        schemaVersion: 3
+      }
+    };
+    fs.readFile.mockResolvedValue(JSON.stringify(cachedData));
+    fs.writeFile.mockResolvedValue();
+    fs.rename.mockResolvedValue();
+
+    const result = await getCachedWeather('London', 'auto');
+
+    expect(result).toEqual({ current: { temp: 20 } });
+
+    // lastAccessed should NOT have been updated — the value stays at 1 min ago
+    const writtenContent = fs.writeFile.mock.calls[0][1];
+    const parsed = JSON.parse(writtenContent);
+    expect(parsed['London-auto'].lastAccessed).toBe(now - 1 * 60 * 1000);
   });
 
   it('getCachedWeather does not update lastAccessed on miss', async () => {

--- a/tests/unit/cache.test.js
+++ b/tests/unit/cache.test.js
@@ -488,10 +488,8 @@ describe('LRU eviction across invocations', () => {
 
     expect(result).toEqual({ current: { temp: 20 } });
 
-    // lastAccessed should NOT have been updated — the value stays at 1 min ago
-    const writtenContent = fs.writeFile.mock.calls[0][1];
-    const parsed = JSON.parse(writtenContent);
-    expect(parsed['London-auto'].lastAccessed).toBe(now - 1 * 60 * 1000);
+    // No write should occur when access is within threshold
+    expect(fs.writeFile).not.toHaveBeenCalled();
   });
 
   it('getCachedWeather does not update lastAccessed on miss', async () => {
@@ -502,10 +500,8 @@ describe('LRU eviction across invocations', () => {
     const result = await getCachedWeather('Unknown', 'auto');
     expect(result).toBeNull();
 
-    // mergeAndSave still writes the cache, but no entry was modified
-    const writtenContent = fs.writeFile.mock.calls[0][1];
-    const parsed = JSON.parse(writtenContent);
-    expect(Object.keys(parsed)).toHaveLength(0);
+    // No write should occur on a cache miss
+    expect(fs.writeFile).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/unit/config.test.js
+++ b/tests/unit/config.test.js
@@ -26,6 +26,8 @@ const {
   getDefaultUnits,
   setDefaultLocation,
   setDefaultUnits,
+  getCacheTtl,
+  setCacheTtl,
   getAsciiConfig,
   processTemperatureOptions,
   __resetForTesting
@@ -230,5 +232,41 @@ describe('processTemperatureOptions', () => {
 
   it('prioritizes --fahrenheit flag over units option', () => {
     expect(processTemperatureOptions({ fahrenheit: true, units: 'metric' })).toBe('fahrenheit');
+  });
+});
+
+describe('cache TTL', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fs.writeFile.mockResolvedValue();
+    fs.rename.mockResolvedValue();
+  });
+
+  it('getCacheTtl returns null when not set', async () => {
+    fs.readFile.mockResolvedValue(JSON.stringify({ defaultLocation: 'London' }));
+    expect(await getCacheTtl()).toBeNull();
+  });
+
+  it('getCacheTtl returns the configured value', async () => {
+    fs.readFile.mockResolvedValue(JSON.stringify({ cacheTtl: 60 }));
+    expect(await getCacheTtl()).toBe(60);
+  });
+
+  it('setCacheTtl writes the value to config', async () => {
+    fs.readFile.mockResolvedValue(JSON.stringify({ defaultLocation: 'Paris' }));
+    await setCacheTtl(120);
+    const writtenContent = fs.writeFile.mock.calls[0][1];
+    const parsed = JSON.parse(writtenContent);
+    expect(parsed.cacheTtl).toBe(120);
+    expect(parsed.defaultLocation).toBe('Paris');
+  });
+
+  it('setCacheTtl with null removes the key', async () => {
+    fs.readFile.mockResolvedValue(JSON.stringify({ cacheTtl: 60, defaultLocation: 'NYC' }));
+    await setCacheTtl(null);
+    const writtenContent = fs.writeFile.mock.calls[0][1];
+    const parsed = JSON.parse(writtenContent);
+    expect(parsed.cacheTtl).toBeUndefined();
+    expect(parsed.defaultLocation).toBe('NYC');
   });
 });

--- a/tests/unit/locationParser.test.js
+++ b/tests/unit/locationParser.test.js
@@ -1,72 +1,39 @@
 import { describe, it, expect } from 'vitest';
-import { parseLocation, STATE_MAPPINGS, MAJOR_CITIES } from '../../src/utils/locationParser.js';
+import { parseLocation } from '../../src/utils/locationParser.js';
 
 describe('parseLocation', () => {
-  describe('state/country code lookup', () => {
-    it('resolves US state codes', () => {
-      expect(parseLocation(['CA'])).toBe('California, US');
-      expect(parseLocation(['NY'])).toBe('New York, US');
-      expect(parseLocation(['TX'])).toBe('Texas, US');
+  describe('basic joining', () => {
+    it('joins multiple words into a location string', () => {
+      expect(parseLocation(['San', 'Ramon', 'CA'])).toBe('San Ramon CA');
     });
 
-    it('resolves Canadian province codes', () => {
-      expect(parseLocation(['BC'])).toBe('British Columbia, CA');
-      expect(parseLocation(['ON'])).toBe('Ontario, CA');
+    it('returns single-word locations as-is', () => {
+      expect(parseLocation(['London'])).toBe('London');
     });
 
-    it('resolves country codes', () => {
-      expect(parseLocation(['UK'])).toBe('United Kingdom');
-    });
-  });
-
-  describe('major city lookup', () => {
-    it('resolves well-known US cities', () => {
-      expect(parseLocation(['New', 'York'])).toBe('New York, NY, US');
-      expect(parseLocation(['San', 'Francisco'])).toBe('San Francisco, CA, US');
-      expect(parseLocation(['San', 'Ramon'])).toBe('San Ramon, CA, US');
-      expect(parseLocation(['Miami'])).toBe('Miami, FL, US');
-      expect(parseLocation(['Seattle'])).toBe('Seattle, WA, US');
-    });
-
-    it('resolves international cities', () => {
-      expect(parseLocation(['London'])).toBe('London, UK');
-      expect(parseLocation(['Tokyo'])).toBe('Tokyo, JP');
-      expect(parseLocation(['Paris'])).toBe('Paris, FR');
-      expect(parseLocation(['Toronto'])).toBe('Toronto, CA');
-      expect(parseLocation(['Vancouver'])).toBe('Vancouver, CA');
-      expect(parseLocation(['Berlin'])).toBe('Berlin, DE');
-      expect(parseLocation(['Sydney'])).toBe('Sydney, AU');
-    });
-  });
-
-  describe('city + state/province parsing', () => {
-    it('parses US city + state as "City, STATE, US"', () => {
-      expect(parseLocation(['San', 'Ramon', 'CA'])).toBe('San Ramon, CA, US');
-      expect(parseLocation(['Los', 'Angeles', 'CA'])).toBe('Los Angeles, CA, US');
-    });
-
-    it('parses Canadian city + province with correct country code', () => {
-      expect(parseLocation(['Vancouver', 'BC'])).toBe('Vancouver, BC, CA');
-      expect(parseLocation(['Toronto', 'ON'])).toBe('Toronto, ON, CA');
-      expect(parseLocation(['Calgary', 'AB'])).toBe('Calgary, AB, CA');
-    });
-
-    it('parses unknown short codes as generic code', () => {
-      expect(parseLocation(['Random', 'City', 'XY'])).toBe('Random City, XY');
+    it('returns plain text for unrecognized single-word locations', () => {
+      expect(parseLocation(['Timbuktu'])).toBe('Timbuktu');
     });
   });
 
   describe('option filtering', () => {
-    it('filters out CLI options', () => {
-      expect(parseLocation(['San', 'Ramon', 'CA', '--celsius'])).toBe('San Ramon, CA, US');
-      expect(parseLocation(['-u', 'metric', 'London'])).toBe('London, UK');
-      expect(parseLocation(['Paris', '--fahrenheit', '-f'])).toBe('Paris, FR');
+    it('filters out CLI flags', () => {
+      expect(parseLocation(['San', 'Ramon', 'CA', '--celsius'])).toBe('San Ramon CA');
+    });
+
+    it('filters out unit keywords', () => {
+      expect(parseLocation(['-u', 'metric', 'London'])).toBe('London');
+      expect(parseLocation(['Paris', '--fahrenheit', '-f'])).toBe('Paris');
     });
   });
 
-  describe('comma-separated input', () => {
+  describe('comma handling', () => {
     it('normalizes spacing around commas', () => {
       expect(parseLocation(['City,', 'State'])).toBe('City, State');
+    });
+
+    it('preserves existing comma-separated format', () => {
+      expect(parseLocation(['San Ramon, CA, US'])).toBe('San Ramon, CA, US');
     });
   });
 
@@ -79,34 +46,5 @@ describe('parseLocation', () => {
     it('returns null when only options are provided', () => {
       expect(parseLocation(['--celsius', '-f'])).toBeNull();
     });
-
-    it('returns plain text for unrecognized single-word locations', () => {
-      expect(parseLocation(['Timbuktu'])).toBe('Timbuktu');
-    });
-  });
-});
-
-describe('STATE_MAPPINGS', () => {
-  it('contains US state entries (some overlap with country/province codes)', () => {
-    const usEntries = Object.entries(STATE_MAPPINGS).filter(([_, v]) => v.endsWith(', US'));
-    // Some US state codes (IN, NE) are overwritten by country codes later in the object
-    expect(usEntries.length).toBeGreaterThanOrEqual(49);
-  });
-
-  it('contains Canadian provinces', () => {
-    const caEntries = Object.entries(STATE_MAPPINGS).filter(([_, v]) => v.endsWith(', CA'));
-    expect(caEntries.length).toBeGreaterThanOrEqual(13);
-  });
-});
-
-describe('MAJOR_CITIES', () => {
-  it('contains entries for common US cities', () => {
-    expect(MAJOR_CITIES['san francisco']).toBe('San Francisco, CA, US');
-    expect(MAJOR_CITIES['new york']).toBe('New York, NY, US');
-  });
-
-  it('contains entries for international cities', () => {
-    expect(MAJOR_CITIES['london']).toBe('London, UK');
-    expect(MAJOR_CITIES['tokyo']).toBe('Tokyo, JP');
   });
 });

--- a/tests/unit/openmeteo.test.js
+++ b/tests/unit/openmeteo.test.js
@@ -113,6 +113,17 @@ describe('parseLocationQuery', () => {
     expect(result.country).toBe('US');
     expect(result.admin1).toBe('CA');
   });
+
+  it('respects explicit country in 3-part input over state-code overlap', () => {
+    // "Toronto, ON, CA" → country=CA (Canada), admin1=ON
+    // Without the parts.length === 2 guard, CA would match US_STATE_CODES
+    // and incorrectly resolve to country=US, admin1=CA
+    expect(parseLocationQuery('Toronto, ON, CA')).toEqual({
+      name: 'Toronto',
+      country: 'CA',
+      admin1: 'ON'
+    });
+  });
 });
 
 describe('normalizeToOwmShape', () => {

--- a/tests/unit/openmeteo.test.js
+++ b/tests/unit/openmeteo.test.js
@@ -75,6 +75,44 @@ describe('parseLocationQuery', () => {
       admin1: null
     });
   });
+
+  it('recognizes US state codes as admin1 hints with country=US', () => {
+    expect(parseLocationQuery('San Ramon, CA')).toEqual({
+      name: 'San Ramon',
+      country: 'US',
+      admin1: 'CA'
+    });
+    expect(parseLocationQuery('New York, NY')).toEqual({
+      name: 'New York',
+      country: 'US',
+      admin1: 'NY'
+    });
+    expect(parseLocationQuery('Miami, FL')).toEqual({
+      name: 'Miami',
+      country: 'US',
+      admin1: 'FL'
+    });
+  });
+
+  it('recognizes Canadian province codes as admin1 with country=CA', () => {
+    expect(parseLocationQuery('Vancouver, BC')).toEqual({
+      name: 'Vancouver',
+      country: 'CA',
+      admin1: 'BC'
+    });
+    expect(parseLocationQuery('Toronto, ON')).toEqual({
+      name: 'Toronto',
+      country: 'CA',
+      admin1: 'ON'
+    });
+  });
+
+  it('does not confuse CA (California) with CA (Canada)', () => {
+    // "San Ramon, CA" → US/California, NOT Canada
+    const result = parseLocationQuery('San Ramon, CA');
+    expect(result.country).toBe('US');
+    expect(result.admin1).toBe('CA');
+  });
 });
 
 describe('normalizeToOwmShape', () => {

--- a/tests/unit/validators.test.js
+++ b/tests/unit/validators.test.js
@@ -33,13 +33,19 @@ describe('validateLocation', () => {
     expect(validateLocation('London')).toBe('London');
   });
 
-  it('converts US state codes in comma-separated format', () => {
-    expect(validateLocation('New York, NY')).toBe('New York, US');
-    expect(validateLocation('San Ramon, CA')).toBe('San Ramon, US');
+  it('passes state codes through unchanged for geocoder disambiguation', () => {
+    // "San Ramon, CA" stays as-is so parseLocationQuery can extract admin1: 'CA'
+    // Rewriting to "San Ramon, US" would strip state-level disambiguation
+    expect(validateLocation('San Ramon, CA')).toBe('San Ramon, CA');
+    expect(validateLocation('New York, NY')).toBe('New York, NY');
   });
 
-  it('passes through country codes as-is', () => {
+  it('passes country codes through as-is', () => {
     expect(validateLocation('London, UK')).toBe('London, UK');
+  });
+
+  it('preserves multi-part locations', () => {
+    expect(validateLocation('San Ramon, CA, US')).toBe('San Ramon, CA, US');
   });
 
   it('throws on empty location', () => {


### PR DESCRIPTION
## Summary

Full codebase review findings, organized by priority. All 363 tests pass, lint clean.

### P1 - Correctness Fixes

**fix: stop stripping state codes in validateLocation, consolidate location parsing**
- Removed `stateToCountry` map from `validators.js` that rewrote `'San Ramon, CA'` to `'San Ramon, US'`, stripping state-level disambiguation before geocoding
- Removed `STATE_MAPPINGS` (50 states + provinces) and `MAJOR_CITIES` (30 hardcoded cities) from `locationParser.js` — the Open-Meteo geocoding API handles all of this
- Added `US_STATE_CODES` and `CA_PROVINCE_CODES` sets to `openmeteo.js` `parseLocationQuery` so `'San Ramon, CA'` correctly resolves to `country=US, admin1=CA` instead of `country=CA` (Canada)
- Simplified `locationParser.js` to just join variadic args and filter CLI flags

**fix: create real animation frames for sunny and cloudy scenes**
- `sunny.js`: all 4 frames were byte-identical (no-op animation). Added ray rotation, wider spread, and sun eye alternation
- `cloudy.js`: all 4 frames were identical. Added cloud drift across frames
- Added frame-difference tests that assert `frames[0] !== frames[1]` for any scene with `frameCount > 1`

### P2 - Cleanup and Polish

**refactor: reduce cache write frequency, route compare through cache, update docs**
- `getCachedWeather`: only write `lastAccessed` if older than 5-min threshold, reducing disk I/O ~80% for status-bar integrations
- `compareWeather`: route through `fetchWithCache` instead of `getWeather` directly
- Updated `CLAUDE.md` and `AGENTS.md`: fixed cache/config file paths (XDG dirs, not repo root), schema version (3), removed stale Playwright reference

### P3 - Future Features

**feat: add configurable cache TTL via config file**
- `getCacheTtl`/`setCacheTtl` in `config.js` (in minutes, clamped 1-1440)
- `cache.js` `getCacheExpiry()` reads from config, falls back to default 30 min
- Added `cacheTtl` prompt to `weather config` interactive command
- 4 new config tests, 2 new cache tests for threshold behavior

## Test Plan
- [x] All 363 tests pass (`npm test`)
- [x] Lint clean (`npm run lint`)
- [x] `weather --help` renders correctly
- [x] No new dependencies added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable cache TTL option to the config command.
* **Bug Fixes**
  * Improved location disambiguation so US state codes and Canadian province codes are handled more accurately.
  * Adjusted cache “last accessed” behavior to reduce unnecessary disk writes while keeping cache freshness.
* **Documentation**
  * Updated cache/config storage locations to XDG-standard paths.
* **Style**
  * Refreshed sunny/cloudy ASCII animations.
* **Tests**
  * Added/expanded unit tests for animation frame variation, cache TTL, and updated location/validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->