### PR TITLE
feat: add UV index with risk level to current weather display

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,5 @@ node_modules/
 coverage/
 .weather-cache.json
 .weather-config.json
+PLAN.md
+STATUS.md

--- a/src/api/openmeteo.js
+++ b/src/api/openmeteo.js
@@ -200,7 +200,8 @@ export async function fetchForecast(lat, lon, { tempUnit, windUnit, includeMinut
       'wind_speed_10m',
       'wind_direction_10m',
       'wind_gusts_10m',
-      'cloud_cover'
+      'cloud_cover',
+      'uv_index'
     ].join(','),
     hourly: [
       'temperature_2m',
@@ -414,6 +415,7 @@ export function normalizeToOwmShape({ place, forecast, airQuality, windUnit = 'm
         gust: cur.wind_gusts_10m
       },
       weather: [curWmo],
+      uv_index: cur.uv_index,
       visibility: visibilityMeters,
       dt
     },

--- a/src/display.js
+++ b/src/display.js
@@ -117,6 +117,20 @@ function getAirQualityDescription(aqi) {
   return desc.color(desc.text);
 }
 
+/**
+ * Format UV index value with WHO risk level label.
+ * @param {number|null|undefined} value - UV index value
+ * @returns {string} Formatted string like "7.4 (High)" or "N/A"
+ */
+function formatUvIndex(value) {
+  if (value === null || value === undefined || Number.isNaN(value)) return 'N/A';
+  if (value < 3) return `${value} (Low)`;
+  if (value < 6) return `${value} (Moderate)`;
+  if (value < 8) return `${value} (High)`;
+  if (value < 11) return `${value} (Very High)`;
+  return `${value} (Extreme)`;
+}
+
 /** Return the most frequent value in an array of numbers. */
 function modeValue(arr) {
   const counts = {};
@@ -307,6 +321,7 @@ function displayCurrentWeather(data, displayUnit, options = {}) {
     formatTemp(weather.main.temp, displayUnit, { colorCode: true, type: 'current' }),
     `Feels Like: ${formatFeelsLike(weather.main.feels_like, displayUnit)}`,
     `Humidity:   ${weather.main.humidity}%`,
+    `UV Index:   ${formatUvIndex(weather.uv_index)}`,
     `Pressure:   ${weather.main.pressure} hPa`
   ];
 
@@ -657,6 +672,7 @@ export {
   formatRelativeTime,
   degToCardinal,
   getAirQualityDescription,
+  formatUvIndex,
   displayCurrentWeather,
   display5DayForecast,
   display24HourForecast,

--- a/tests/unit/display.test.js
+++ b/tests/unit/display.test.js
@@ -8,6 +8,7 @@ import {
   formatRelativeTime,
   degToCardinal,
   getAirQualityDescription,
+  formatUvIndex,
   createDataRow,
   displayAlerts,
   displayMinutelyForecast
@@ -391,5 +392,75 @@ describe('formatTemp null handling', () => {
 
   it('returns N/A for NaN', () => {
     expect(formatTemp(NaN, 'celsius')).toBe('N/A');
+  });
+});
+
+describe('formatUvIndex', () => {
+  it('returns "N/A" for null', () => {
+    expect(formatUvIndex(null)).toBe('N/A');
+  });
+
+  it('returns "N/A" for undefined', () => {
+    expect(formatUvIndex(undefined)).toBe('N/A');
+  });
+
+  it('returns "N/A" for NaN', () => {
+    expect(formatUvIndex(NaN)).toBe('N/A');
+  });
+
+  it('returns Low for value 0', () => {
+    expect(formatUvIndex(0)).toBe('0 (Low)');
+  });
+
+  it('returns Low for value 1', () => {
+    expect(formatUvIndex(1)).toBe('1 (Low)');
+  });
+
+  it('returns Low for value 2', () => {
+    expect(formatUvIndex(2)).toBe('2 (Low)');
+  });
+
+  it('returns Moderate for value 3', () => {
+    expect(formatUvIndex(3)).toBe('3 (Moderate)');
+  });
+
+  it('returns Moderate for value 5', () => {
+    expect(formatUvIndex(5)).toBe('5 (Moderate)');
+  });
+
+  it('returns High for value 6', () => {
+    expect(formatUvIndex(6)).toBe('6 (High)');
+  });
+
+  it('returns High for value 7', () => {
+    expect(formatUvIndex(7)).toBe('7 (High)');
+  });
+
+  it('returns Very High for value 8', () => {
+    expect(formatUvIndex(8)).toBe('8 (Very High)');
+  });
+
+  it('returns Very High for value 10', () => {
+    expect(formatUvIndex(10)).toBe('10 (Very High)');
+  });
+
+  it('returns Extreme for value 11', () => {
+    expect(formatUvIndex(11)).toBe('11 (Extreme)');
+  });
+
+  it('returns Extreme for value 15', () => {
+    expect(formatUvIndex(15)).toBe('15 (Extreme)');
+  });
+
+  it('handles decimal values', () => {
+    expect(formatUvIndex(7.4)).toBe('7.4 (High)');
+  });
+
+  it('handles decimal value in Moderate range', () => {
+    expect(formatUvIndex(4.5)).toBe('4.5 (Moderate)');
+  });
+
+  it('handles decimal value in Very High range', () => {
+    expect(formatUvIndex(9.3)).toBe('9.3 (Very High)');
   });
 });

--- a/tests/unit/openmeteo.test.js
+++ b/tests/unit/openmeteo.test.js
@@ -392,4 +392,29 @@ describe('normalizeToOwmShape', () => {
       expect(data.current.main.feels_like).toBeUndefined();
     });
   });
+
+  it('maps uv_index from current weather data', () => {
+    const forecastWithUv = {
+      ...forecast,
+      current: {
+        ...forecast.current,
+        uv_index: 7.4
+      }
+    };
+    const data = normalizeToOwmShape({
+      place,
+      forecast: forecastWithUv,
+      airQuality: { current: null, hourly: {}, daily: {} }
+    });
+    expect(data.current.uv_index).toBe(7.4);
+  });
+
+  it('sets uv_index to undefined when not present in current weather', () => {
+    const data = normalizeToOwmShape({
+      place,
+      forecast,
+      airQuality: { current: null, hourly: {}, daily: {} }
+    });
+    expect(data.current.uv_index).toBeUndefined();
+  });
 });


### PR DESCRIPTION
Adds UV index display with WHO risk level labels.

Changes:
- Map uv_index from Open-Meteo current weather response
- Add formatUvIndex() with WHO risk levels (Low/Moderate/High/Very High/Extreme)
- Add UV Index line to current weather display
- Add unit tests for formatUvIndex and uv_index mapping
- Add PLAN.md and STATUS.md to .prettierignore

Acceptance criteria from PLAN.md all met. All gates passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * UV index now displayed in current weather with WHO risk-level categories (Low, Moderate, High, Very High, Extreme) to help users assess sun exposure.

* **Tests**
  * Added comprehensive test coverage for UV index formatting and API data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->