### PR TITLE
feat: add cloud cover, precipitation probability, wind description, and daylight duration

### DIFF
--- a/src/api/openmeteo.js
+++ b/src/api/openmeteo.js
@@ -212,9 +212,14 @@ export async function fetchForecast(lat, lon, { tempUnit, windUnit, includeMinut
       'relative_humidity_2m',
       'visibility'
     ].join(','),
-    daily: ['weather_code', 'temperature_2m_max', 'temperature_2m_min', 'sunrise', 'sunset'].join(
-      ','
-    ),
+    daily: [
+      'weather_code',
+      'temperature_2m_max',
+      'temperature_2m_min',
+      'sunrise',
+      'sunset',
+      'precipitation_probability'
+    ].join(','),
     timezone: 'auto',
     forecast_days: 6,
     temperature_unit: tempUnit,
@@ -420,6 +425,7 @@ export function normalizeToOwmShape({ place, forecast, airQuality, windUnit = 'm
       visibility: visibilityMeters,
       dew_point: cur.dew_point_2m,
       cloud_cover: cur.cloud_cover,
+      precip_probability: daily.precipitation_probability?.[0],
       dt
     },
     forecast: { list },

--- a/src/api/openmeteo.js
+++ b/src/api/openmeteo.js
@@ -419,6 +419,7 @@ export function normalizeToOwmShape({ place, forecast, airQuality, windUnit = 'm
       uv_index: cur.uv_index,
       visibility: visibilityMeters,
       dew_point: cur.dew_point_2m,
+      cloud_cover: cur.cloud_cover,
       dt
     },
     forecast: { list },

--- a/src/display.js
+++ b/src/display.js
@@ -155,6 +155,58 @@ function formatUvIndex(value) {
   return `${value} (Extreme)`;
 }
 
+/**
+ * Format precipitation probability value.
+ * @param {number|null|undefined} value - Precipitation probability (0-100)
+ * @returns {string} Formatted value or "N/A"
+ */
+function formatPrecipProbability(value) {
+  if (value === null || value === undefined || Number.isNaN(value)) return 'N/A';
+  return String(value);
+}
+
+/**
+ * Format wind speed as a Beaufort scale description.
+ * @param {number|null|undefined} speed - Wind speed
+ * @param {string} windUnit - 'ms', 'mph', or 'kn'
+ * @returns {string} Beaufort description or "N/A"
+ */
+function formatWindDescription(speed, windUnit) {
+  if (speed === null || speed === undefined || Number.isNaN(speed)) return 'N/A';
+  let ms = speed;
+  if (windUnit === 'mph') ms = speed * 0.44704;
+  else if (windUnit === 'kn') ms = speed * 0.51444;
+  if (ms < 0.5) return 'Calm';
+  if (ms < 1.5) return 'Light air';
+  if (ms < 3.3) return 'Light breeze';
+  if (ms < 5.5) return 'Gentle breeze';
+  if (ms < 7.9) return 'Moderate breeze';
+  if (ms < 10.7) return 'Fresh breeze';
+  if (ms < 13.8) return 'Strong breeze';
+  if (ms < 17.1) return 'High wind';
+  if (ms < 20.7) return 'Gale';
+  if (ms < 24.4) return 'Strong gale';
+  if (ms < 28.4) return 'Storm';
+  if (ms < 32.6) return 'Violent storm';
+  return 'Hurricane';
+}
+
+/**
+ * Format daylight duration from sunrise and sunset timestamps.
+ * @param {number|null|undefined} sunrise - Unix timestamp (seconds)
+ * @param {number|null|undefined} sunset - Unix timestamp (seconds)
+ * @returns {string} Duration like "14h 22m" or "N/A"
+ */
+function formatDaylight(sunrise, sunset) {
+  if (sunrise === null || sunrise === undefined || Number.isNaN(sunrise)) return 'N/A';
+  if (sunset === null || sunset === undefined || Number.isNaN(sunset)) return 'N/A';
+  const diff = sunset - sunrise;
+  if (diff < 0) return 'N/A';
+  const hours = Math.floor(diff / 3600);
+  const minutes = Math.floor((diff % 3600) / 60);
+  return `${hours}h ${minutes}m`;
+}
+
 /** Return the most frequent value in an array of numbers. */
 function modeValue(arr) {
   const counts = {};
@@ -348,15 +400,17 @@ function displayCurrentWeather(data, displayUnit, options = {}) {
     `UV Index:   ${formatUvIndex(weather.uv_index)}`,
     `Pressure:   ${weather.main.pressure} hPa`,
     `Dew Point:  ${formatDewPoint(weather.dew_point, displayUnit)}`,
-    `Cloud Cover: ${weather.cloud_cover ?? 'N/A'}%`
+    `Cloud Cover: ${weather.cloud_cover ?? 'N/A'}%`,
+    `Rain Chance:  ${formatPrecipProbability(weather.precip_probability)}%`
   ];
 
   const right = [
     `Sunrise:     ${formatTime(weather.sys.sunrise)} (${formatRelativeTime(weather.sys.sunrise)})`,
     `Sunset:      ${formatTime(weather.sys.sunset)} (${formatRelativeTime(weather.sys.sunset)})`,
+    `Daylight:    ${formatDaylight(weather.sys.sunrise, weather.sys.sunset)}`,
     aqi ? `Air Quality: ${getAirQualityDescription(aqi)} (AQI: ${aqi})` : '',
     `Min/Max:     ${formatTemp(weather.main.temp_min, displayUnit, { colorCode: true, type: 'min' })} / ${formatTemp(weather.main.temp_max, displayUnit, { colorCode: true, type: 'max' })}`,
-    `Wind:        ${wind}`,
+    `Wind:        ${wind} (${formatWindDescription(weather.wind.speed, windUnit)})`,
     `Visibility:  ${visFormatted}`
   ].filter(Boolean);
 
@@ -705,5 +759,8 @@ export {
   displayAlerts,
   displayMinutelyForecast,
   formatDewPoint,
+  formatPrecipProbability,
+  formatWindDescription,
+  formatDaylight,
   createDataRow
 };

--- a/src/display.js
+++ b/src/display.js
@@ -347,7 +347,8 @@ function displayCurrentWeather(data, displayUnit, options = {}) {
     `Humidity:   ${weather.main.humidity}%`,
     `UV Index:   ${formatUvIndex(weather.uv_index)}`,
     `Pressure:   ${weather.main.pressure} hPa`,
-    `Dew Point:  ${formatDewPoint(weather.dew_point, displayUnit)}`
+    `Dew Point:  ${formatDewPoint(weather.dew_point, displayUnit)}`,
+    `Cloud Cover: ${weather.cloud_cover ?? 'N/A'}%`
   ];
 
   const right = [

--- a/tests/unit/display.test.js
+++ b/tests/unit/display.test.js
@@ -12,7 +12,8 @@ import {
   formatDewPoint,
   createDataRow,
   displayAlerts,
-  displayMinutelyForecast
+  displayMinutelyForecast,
+  displayCurrentWeather
 } from '../../src/display.js';
 
 describe('formatTemp', () => {
@@ -533,5 +534,69 @@ describe('formatDewPoint', () => {
 
   it('respects boundary: 23.9 is Severe not Oppressive', () => {
     expect(formatDewPoint(23.9, 'celsius')).toBe('24°C (Severe)');
+  });
+});
+
+describe('displayCurrentWeather - Cloud Cover', () => {
+  it('displays Cloud Cover in the output', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const data = {
+      current: {
+        name: 'Test City',
+        sys: { country: 'US', sunrise: 1700000000, sunset: 1700040000 },
+        main: {
+          temp: 72,
+          feels_like: 70,
+          humidity: 55,
+          pressure: 1015,
+          temp_min: 52,
+          temp_max: 76
+        },
+        wind: { speed: 5, deg: 270, gust: 9 },
+        weather: [{ id: 802, main: 'Clouds', description: 'partly cloudy' }],
+        uv_index: 5,
+        visibility: 12000,
+        dew_point: 14,
+        cloud_cover: 40
+      },
+      pollution: { list: [{ main: { aqi: 1 } }] },
+      windUnit: 'ms'
+    };
+    displayCurrentWeather(data, 'celsius');
+    const output = spy.mock.calls.map((args) => args.join('')).join('\n');
+    expect(output).toContain('Cloud Cover');
+    expect(output).toContain('40%');
+    spy.mockRestore();
+  });
+
+  it('displays N/A for Cloud Cover when null', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const data = {
+      current: {
+        name: 'Test City',
+        sys: { country: 'US', sunrise: 1700000000, sunset: 1700040000 },
+        main: {
+          temp: 72,
+          feels_like: 70,
+          humidity: 55,
+          pressure: 1015,
+          temp_min: 52,
+          temp_max: 76
+        },
+        wind: { speed: 5, deg: 270, gust: 9 },
+        weather: [{ id: 802, main: 'Clouds', description: 'partly cloudy' }],
+        uv_index: 5,
+        visibility: 12000,
+        dew_point: 14,
+        cloud_cover: null
+      },
+      pollution: { list: [{ main: { aqi: 1 } }] },
+      windUnit: 'ms'
+    };
+    displayCurrentWeather(data, 'celsius');
+    const output = spy.mock.calls.map((args) => args.join('')).join('\n');
+    expect(output).toContain('Cloud Cover');
+    expect(output).toContain('N/A%');
+    spy.mockRestore();
   });
 });

--- a/tests/unit/display.test.js
+++ b/tests/unit/display.test.js
@@ -10,6 +10,9 @@ import {
   getAirQualityDescription,
   formatUvIndex,
   formatDewPoint,
+  formatPrecipProbability,
+  formatWindDescription,
+  formatDaylight,
   createDataRow,
   displayAlerts,
   displayMinutelyForecast,
@@ -598,5 +601,139 @@ describe('displayCurrentWeather - Cloud Cover', () => {
     expect(output).toContain('Cloud Cover');
     expect(output).toContain('N/A%');
     spy.mockRestore();
+  });
+});
+
+describe('formatPrecipProbability', () => {
+  it('returns "N/A" for null', () => {
+    expect(formatPrecipProbability(null)).toBe('N/A');
+  });
+
+  it('returns "N/A" for undefined', () => {
+    expect(formatPrecipProbability(undefined)).toBe('N/A');
+  });
+
+  it('returns "N/A" for NaN', () => {
+    expect(formatPrecipProbability(NaN)).toBe('N/A');
+  });
+
+  it('returns value as string for 0', () => {
+    expect(formatPrecipProbability(0)).toBe('0');
+  });
+
+  it('returns value as string for 30', () => {
+    expect(formatPrecipProbability(30)).toBe('30');
+  });
+
+  it('returns value as string for 100', () => {
+    expect(formatPrecipProbability(100)).toBe('100');
+  });
+});
+
+describe('formatWindDescription', () => {
+  it('returns "N/A" for null', () => {
+    expect(formatWindDescription(null, 'ms')).toBe('N/A');
+  });
+
+  it('returns "N/A" for undefined', () => {
+    expect(formatWindDescription(undefined, 'ms')).toBe('N/A');
+  });
+
+  it('returns "N/A" for NaN', () => {
+    expect(formatWindDescription(NaN, 'ms')).toBe('N/A');
+  });
+
+  it('returns Calm for 0 m/s', () => {
+    expect(formatWindDescription(0, 'ms')).toBe('Calm');
+  });
+
+  it('returns Light air for 1 m/s', () => {
+    expect(formatWindDescription(1, 'ms')).toBe('Light air');
+  });
+
+  it('returns Light breeze for 2 m/s', () => {
+    expect(formatWindDescription(2, 'ms')).toBe('Light breeze');
+  });
+
+  it('returns Gentle breeze for 4 m/s', () => {
+    expect(formatWindDescription(4, 'ms')).toBe('Gentle breeze');
+  });
+
+  it('returns Moderate breeze for 6 m/s', () => {
+    expect(formatWindDescription(6, 'ms')).toBe('Moderate breeze');
+  });
+
+  it('returns Fresh breeze for 9 m/s', () => {
+    expect(formatWindDescription(9, 'ms')).toBe('Fresh breeze');
+  });
+
+  it('returns Strong breeze for 12 m/s', () => {
+    expect(formatWindDescription(12, 'ms')).toBe('Strong breeze');
+  });
+
+  it('returns High wind for 15 m/s', () => {
+    expect(formatWindDescription(15, 'ms')).toBe('High wind');
+  });
+
+  it('returns Gale for 19 m/s', () => {
+    expect(formatWindDescription(19, 'ms')).toBe('Gale');
+  });
+
+  it('returns Strong gale for 23 m/s', () => {
+    expect(formatWindDescription(23, 'ms')).toBe('Strong gale');
+  });
+
+  it('returns Storm for 27 m/s', () => {
+    expect(formatWindDescription(27, 'ms')).toBe('Storm');
+  });
+
+  it('returns Violent storm for 30 m/s', () => {
+    expect(formatWindDescription(30, 'ms')).toBe('Violent storm');
+  });
+
+  it('returns Hurricane for 33 m/s', () => {
+    expect(formatWindDescription(33, 'ms')).toBe('Hurricane');
+  });
+
+  it('converts mph to m/s correctly (10 mph = Gentle breeze)', () => {
+    expect(formatWindDescription(10, 'mph')).toBe('Gentle breeze');
+  });
+
+  it('converts kn to m/s correctly (10 kn = Gentle breeze)', () => {
+    expect(formatWindDescription(10, 'kn')).toBe('Gentle breeze');
+  });
+});
+
+describe('formatDaylight', () => {
+  it('returns "N/A" for null sunrise', () => {
+    expect(formatDaylight(null, 1700030000)).toBe('N/A');
+  });
+
+  it('returns "N/A" for null sunset', () => {
+    expect(formatDaylight(1699990000, null)).toBe('N/A');
+  });
+
+  it('returns "N/A" for both null', () => {
+    expect(formatDaylight(null, null)).toBe('N/A');
+  });
+
+  it('returns "N/A" for undefined sunrise', () => {
+    expect(formatDaylight(undefined, 1700030000)).toBe('N/A');
+  });
+
+  it('returns "N/A" for NaN sunrise', () => {
+    expect(formatDaylight(NaN, 1700030000)).toBe('N/A');
+  });
+
+  it('calculates daylight duration correctly (11h 6m)', () => {
+    expect(formatDaylight(1699990000, 1700030000)).toBe('11h 6m');
+  });
+
+  it('returns 0h 0m when sunrise equals sunset', () => {
+    expect(formatDaylight(1699990000, 1699990000)).toBe('0h 0m');
+  });
+
+  it('returns "N/A" for negative duration (sunset before sunrise)', () => {
+    expect(formatDaylight(1700030000, 1699990000)).toBe('N/A');
   });
 });

--- a/tests/unit/openmeteo.test.js
+++ b/tests/unit/openmeteo.test.js
@@ -468,4 +468,29 @@ describe('normalizeToOwmShape', () => {
     });
     expect(data.current.cloud_cover).toBeUndefined();
   });
+
+  it('maps precip_probability from daily forecast data', () => {
+    const forecastWithPrecip = {
+      ...forecast,
+      daily: {
+        ...forecast.daily,
+        precipitation_probability: [30, 10, 5, 0, 20, 40]
+      }
+    };
+    const data = normalizeToOwmShape({
+      place,
+      forecast: forecastWithPrecip,
+      airQuality: { current: null, hourly: {}, daily: {} }
+    });
+    expect(data.current.precip_probability).toBe(30);
+  });
+
+  it('sets precip_probability to undefined when not present in daily data', () => {
+    const data = normalizeToOwmShape({
+      place,
+      forecast,
+      airQuality: { current: null, hourly: {}, daily: {} }
+    });
+    expect(data.current.precip_probability).toBeUndefined();
+  });
 });

--- a/tests/unit/openmeteo.test.js
+++ b/tests/unit/openmeteo.test.js
@@ -443,4 +443,29 @@ describe('normalizeToOwmShape', () => {
     });
     expect(data.current.dew_point).toBeUndefined();
   });
+
+  it('maps cloud_cover from current weather data', () => {
+    const data = normalizeToOwmShape({
+      place,
+      forecast,
+      airQuality: { current: null, hourly: {}, daily: {} }
+    });
+    expect(data.current.cloud_cover).toBe(40);
+  });
+
+  it('sets cloud_cover to undefined when not present in current weather', () => {
+    const forecastNoCloud = {
+      ...forecast,
+      current: {
+        ...forecast.current,
+        cloud_cover: undefined
+      }
+    };
+    const data = normalizeToOwmShape({
+      place,
+      forecast: forecastNoCloud,
+      airQuality: { current: null, hourly: {}, daily: {} }
+    });
+    expect(data.current.cloud_cover).toBeUndefined();
+  });
 });


### PR DESCRIPTION
Adds 4 new weather data points to the current weather display.

## Features (stacked commits)
1. **Cloud cover percentage** — mapped from Open-Meteo current weather, displayed as `Cloud Cover: 40%`
2. **Precipitation probability** — requested from daily params, displayed as `Rain Chance: 30%`
3. **Beaufort wind description** — derived from wind speed with unit conversion (mph/kn to m/s), displayed as `Wind: 15 mph (Fresh breeze)`
4. **Daylight duration** — calculated from sunrise/sunset timestamps, displayed as `Daylight: 14h 22m`

## New functions
- `formatPrecipProbability(value)` — null-safe percentage formatter
- `formatWindDescription(speed, windUnit)` — 13 Beaufort scale levels with unit conversion
- `formatDaylight(sunrise, sunset)` — duration calculator from Unix timestamps

## Tests
- 452 total (38 new tests across display and openmeteo test suites)
- All gates passing: 0 lint errors, format clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Cloud cover now displayed in weather information
  * Precipitation probability (rain chance) added to current weather
  * Daylight duration now visible on weather display
  * Wind information enhanced with descriptive text based on wind speed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->