### PR TITLE
feat: add barometric pressure trend and moon phase to current weather

### DIFF
--- a/src/api/openmeteo.js
+++ b/src/api/openmeteo.js
@@ -210,6 +210,7 @@ export async function fetchForecast(lat, lon, { tempUnit, windUnit, includeMinut
       'wind_speed_10m',
       'wind_direction_10m',
       'relative_humidity_2m',
+      'pressure_msl',
       'visibility'
     ].join(','),
     daily: [
@@ -319,6 +320,22 @@ export function normalizeToOwmShape({ place, forecast, airQuality, windUnit = 'm
   const curWmo = wmoToOwm(cur.weather_code);
   const curIdx = nearestHourlyIndex(hourly.time || [], cur.time);
   const visibilityMeters = hourly.visibility?.[curIdx] ?? 10000;
+  // Compute barometric pressure trend (3-hour tendency)
+  const curPressure = cur.pressure_msl ?? null;
+  const hourlyPressures = hourly.pressure_msl || [];
+  let pressureTrend = null;
+  if (
+    curPressure !== null &&
+    curIdx >= 3 &&
+    hourlyPressures[curIdx - 3] !== null &&
+    hourlyPressures[curIdx - 3] !== undefined &&
+    !Number.isNaN(hourlyPressures[curIdx - 3])
+  ) {
+    const pressure3hAgo = hourlyPressures[curIdx - 3];
+    const delta = Math.round((curPressure - pressure3hAgo) * 10) / 10;
+    const trend = delta > 0.5 ? 'rising' : delta < -0.5 ? 'falling' : 'steady';
+    pressureTrend = { trend, delta, pressure_3h_ago: pressure3hAgo };
+  }
 
   const sunriseIso = daily.sunrise?.[0];
   const sunsetIso = daily.sunset?.[0];
@@ -426,6 +443,7 @@ export function normalizeToOwmShape({ place, forecast, airQuality, windUnit = 'm
       dew_point: cur.dew_point_2m,
       cloud_cover: cur.cloud_cover,
       precip_probability: daily.precipitation_probability?.[0],
+      pressure_trend: pressureTrend,
       dt
     },
     forecast: { list },

--- a/src/display.js
+++ b/src/display.js
@@ -3,6 +3,7 @@ import boxen from 'boxen';
 import { getScene, isDaytime } from './ascii/index.js';
 import { AsciiRenderer } from './ascii/renderer.js';
 import { renderBrailleLineChart, dataPointColumns, buildLabelRow } from './ascii/sparkline.js';
+import { getMoonPhase } from './utils/moon.js';
 import { weatherEmojis } from './utils/icons.js';
 
 function formatTemp(temp, displayUnit, options = {}) {
@@ -214,6 +215,11 @@ function formatPressureTrend(trend, delta) {
   return chalk.gray(`(→ ±${Math.abs(delta).toFixed(1)})`);
 }
 
+function formatMoonPhase(moonData) {
+  if (!moonData) return 'N/A';
+  return `${moonData.emoji} ${moonData.name} (${moonData.illumination}% illuminated)`;
+}
+
 /** Return the most frequent value in an array of numbers. */
 function modeValue(arr) {
   const counts = {};
@@ -415,6 +421,7 @@ function displayCurrentWeather(data, displayUnit, options = {}) {
     `Sunrise:     ${formatTime(weather.sys.sunrise)} (${formatRelativeTime(weather.sys.sunrise)})`,
     `Sunset:      ${formatTime(weather.sys.sunset)} (${formatRelativeTime(weather.sys.sunset)})`,
     `Daylight:    ${formatDaylight(weather.sys.sunrise, weather.sys.sunset)}`,
+    `Moon:        ${formatMoonPhase(getMoonPhase())}`,
     aqi ? `Air Quality: ${getAirQualityDescription(aqi)} (AQI: ${aqi})` : '',
     `Min/Max:     ${formatTemp(weather.main.temp_min, displayUnit, { colorCode: true, type: 'min' })} / ${formatTemp(weather.main.temp_max, displayUnit, { colorCode: true, type: 'max' })}`,
     `Wind:        ${wind} (${formatWindDescription(weather.wind.speed, windUnit)})`,
@@ -770,5 +777,6 @@ export {
   formatWindDescription,
   formatDaylight,
   formatPressureTrend,
+  formatMoonPhase,
   createDataRow
 };

--- a/src/display.js
+++ b/src/display.js
@@ -207,6 +207,13 @@ function formatDaylight(sunrise, sunset) {
   return `${hours}h ${minutes}m`;
 }
 
+function formatPressureTrend(trend, delta) {
+  if (trend === null || trend === undefined) return '';
+  if (trend === 'rising') return chalk.blue(`(↑ +${Math.abs(delta).toFixed(1)})`);
+  if (trend === 'falling') return chalk.red(`(↓ -${Math.abs(delta).toFixed(1)})`);
+  return chalk.gray(`(→ ±${Math.abs(delta).toFixed(1)})`);
+}
+
 /** Return the most frequent value in an array of numbers. */
 function modeValue(arr) {
   const counts = {};
@@ -398,7 +405,7 @@ function displayCurrentWeather(data, displayUnit, options = {}) {
     `Feels Like: ${formatFeelsLike(weather.main.feels_like, displayUnit)}`,
     `Humidity:   ${weather.main.humidity}%`,
     `UV Index:   ${formatUvIndex(weather.uv_index)}`,
-    `Pressure:   ${weather.main.pressure} hPa`,
+    `Pressure:   ${weather.main.pressure} hPa ${formatPressureTrend(weather.pressure_trend?.trend, weather.pressure_trend?.delta)}`,
     `Dew Point:  ${formatDewPoint(weather.dew_point, displayUnit)}`,
     `Cloud Cover: ${weather.cloud_cover ?? 'N/A'}%`,
     `Rain Chance:  ${formatPrecipProbability(weather.precip_probability)}%`
@@ -762,5 +769,6 @@ export {
   formatPrecipProbability,
   formatWindDescription,
   formatDaylight,
+  formatPressureTrend,
   createDataRow
 };

--- a/src/utils/moon.js
+++ b/src/utils/moon.js
@@ -1,0 +1,58 @@
+/**
+ * Moon phase calculator — pure astronomical math, no API dependency.
+ * Algorithm: Julian date -> synodic period -> phase angle -> illumination.
+ */
+
+/**
+ * Calculate the current moon phase for a given date.
+ * @param {Date} [date=new Date()] - The date to calculate the moon phase for.
+ * @returns {{phase: number, illumination: number, name: string, emoji: string}}
+ */
+export function getMoonPhase(date = new Date()) {
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+
+  // Julian date calculation
+  const jd =
+    367 * year -
+    Math.floor((7 * (year + Math.floor((month + 9) / 12))) / 4) -
+    Math.floor((3 * (Math.floor((year + (month - 9) / 7) / 100) + 1)) / 4) +
+    Math.floor((275 * month) / 9) +
+    day +
+    1721028.5 +
+    (date.getHours() + date.getMinutes() / 60 + date.getSeconds() / 3600) / 24;
+
+  // Known new moon: 2000-01-06 18:14 UTC = JD 2451550.1
+  const knownNewMoon = 2451550.1;
+  const synodicMonth = 29.53059; // days
+
+  // Phase: 0 = new moon, 0.5 = full moon, approaching 1 = next new moon
+  let phase = ((jd - knownNewMoon) % synodicMonth) / synodicMonth;
+  if (phase < 0) phase += 1;
+
+  // Illumination: fraction of moon face illuminated (0-1, then *100 for percent)
+  // illumination = (1 - cos(2*pi*phase)) / 2
+  const illumination = Math.round(((1 - Math.cos(2 * Math.PI * phase)) / 2) * 100);
+
+  // Phase name and emoji
+  const phases = [
+    { name: 'New Moon', emoji: '\u{1F311}' },
+    { name: 'Waxing Crescent', emoji: '\u{1F312}' },
+    { name: 'First Quarter', emoji: '\u{1F313}' },
+    { name: 'Waxing Gibbous', emoji: '\u{1F314}' },
+    { name: 'Full Moon', emoji: '\u{1F315}' },
+    { name: 'Waning Gibbous', emoji: '\u{1F316}' },
+    { name: 'Last Quarter', emoji: '\u{1F317}' },
+    { name: 'Waning Crescent', emoji: '\u{1F318}' }
+  ];
+
+  const phaseIndex = Math.floor(phase * 8 + 0.5) % 8;
+
+  return {
+    phase, // 0-1
+    illumination, // 0-100 (percentage)
+    name: phases[phaseIndex].name,
+    emoji: phases[phaseIndex].emoji
+  };
+}

--- a/tests/unit/display.test.js
+++ b/tests/unit/display.test.js
@@ -14,6 +14,7 @@ import {
   formatWindDescription,
   formatDaylight,
   formatPressureTrend,
+  formatMoonPhase,
   createDataRow,
   displayAlerts,
   displayMinutelyForecast,
@@ -771,5 +772,30 @@ describe('formatPressureTrend', () => {
     expect(rising).toContain('+5.0');
     const falling = formatPressureTrend('falling', -5.0);
     expect(falling).toContain('5.0');
+  });
+});
+
+describe('formatMoonPhase', () => {
+  it('returns N/A for null input', () => {
+    expect(formatMoonPhase(null)).toBe('N/A');
+  });
+
+  it('returns N/A for undefined input', () => {
+    expect(formatMoonPhase(undefined)).toBe('N/A');
+  });
+
+  it('formats a valid moon phase object', () => {
+    const moonData = { emoji: '🌕', name: 'Full Moon', illumination: 100, phase: 0.5 };
+    const result = formatMoonPhase(moonData);
+    expect(result).toContain('Full Moon');
+    expect(result).toContain('100%');
+    expect(result).toContain('illuminated');
+  });
+
+  it('formats a crescent moon correctly', () => {
+    const moonData = { emoji: '🌒', name: 'Waxing Crescent', illumination: 15, phase: 0.0625 };
+    const result = formatMoonPhase(moonData);
+    expect(result).toContain('Waxing Crescent');
+    expect(result).toContain('15%');
   });
 });

--- a/tests/unit/display.test.js
+++ b/tests/unit/display.test.js
@@ -13,6 +13,7 @@ import {
   formatPrecipProbability,
   formatWindDescription,
   formatDaylight,
+  formatPressureTrend,
   createDataRow,
   displayAlerts,
   displayMinutelyForecast,
@@ -735,5 +736,40 @@ describe('formatDaylight', () => {
 
   it('returns "N/A" for negative duration (sunset before sunrise)', () => {
     expect(formatDaylight(1700030000, 1699990000)).toBe('N/A');
+  });
+});
+
+describe('formatPressureTrend', () => {
+  it('returns empty string for null trend', () => {
+    expect(formatPressureTrend(null, 1.0)).toBe('');
+  });
+
+  it('returns empty string for undefined trend', () => {
+    expect(formatPressureTrend(undefined, 1.0)).toBe('');
+  });
+
+  it('returns blue rising indicator for rising trend', () => {
+    const result = formatPressureTrend('rising', 2.1);
+    expect(result).toContain('↑');
+    expect(result).toContain('+2.1');
+  });
+
+  it('returns red falling indicator for falling trend', () => {
+    const result = formatPressureTrend('falling', -3.2);
+    expect(result).toContain('↓');
+    expect(result).toContain('3.2');
+  });
+
+  it('returns gray steady indicator for steady trend', () => {
+    const result = formatPressureTrend('steady', 0.1);
+    expect(result).toContain('→');
+    expect(result).toContain('0.1');
+  });
+
+  it('uses absolute value for delta display', () => {
+    const rising = formatPressureTrend('rising', 5.0);
+    expect(rising).toContain('+5.0');
+    const falling = formatPressureTrend('falling', -5.0);
+    expect(falling).toContain('5.0');
   });
 });

--- a/tests/unit/moon.test.js
+++ b/tests/unit/moon.test.js
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { getMoonPhase } from '../../src/utils/moon.js';
+
+describe('getMoonPhase', () => {
+  it('returns an object with phase, illumination, name, and emoji', () => {
+    const result = getMoonPhase(new Date('2025-06-15T12:00:00'));
+    expect(result).toHaveProperty('phase');
+    expect(result).toHaveProperty('illumination');
+    expect(result).toHaveProperty('name');
+    expect(result).toHaveProperty('emoji');
+  });
+
+  it('returns phase between 0 and 1', () => {
+    const result = getMoonPhase(new Date('2025-06-15T12:00:00'));
+    expect(result.phase).toBeGreaterThanOrEqual(0);
+    expect(result.phase).toBeLessThan(1);
+  });
+
+  it('returns illumination between 0 and 100', () => {
+    const result = getMoonPhase(new Date('2025-06-15T12:00:00'));
+    expect(result.illumination).toBeGreaterThanOrEqual(0);
+    expect(result.illumination).toBeLessThanOrEqual(100);
+  });
+
+  it('returns a valid phase name from the 8 known phases', () => {
+    const validNames = [
+      'New Moon',
+      'Waxing Crescent',
+      'First Quarter',
+      'Waxing Gibbous',
+      'Full Moon',
+      'Waning Gibbous',
+      'Last Quarter',
+      'Waning Crescent'
+    ];
+    const result = getMoonPhase(new Date('2025-06-15T12:00:00'));
+    expect(validNames).toContain(result.name);
+  });
+
+  it('returns a valid emoji', () => {
+    const validEmojis = ['🌑', '🌒', '🌓', '🌔', '🌕', '🌖', '🌗', '🌘'];
+    const result = getMoonPhase(new Date('2025-06-15T12:00:00'));
+    expect(validEmojis).toContain(result.emoji);
+  });
+
+  it('works with default parameter (no date passed)', () => {
+    const result = getMoonPhase();
+    expect(result).toHaveProperty('phase');
+    expect(result).toHaveProperty('name');
+  });
+
+  it('returns near full moon for 2025-01-13 (Wolf Moon)', () => {
+    const result = getMoonPhase(new Date('2025-01-13T22:00:00Z'));
+    // Full moon was Jan 13 2025 at ~22:27 UTC
+    // Illumination should be very high (95-100%)
+    expect(result.illumination).toBeGreaterThan(90);
+  });
+
+  it('returns near new moon for 2025-01-29', () => {
+    const result = getMoonPhase(new Date('2025-01-29T12:00:00Z'));
+    // New moon was Jan 29 2025 at ~12:36 UTC
+    // Illumination should be very low (0-5%)
+    expect(result.illumination).toBeLessThan(10);
+  });
+
+  it('produces different phases for different dates', () => {
+    const date1 = getMoonPhase(new Date('2025-01-13T12:00:00Z'));
+    const date2 = getMoonPhase(new Date('2025-02-12T12:00:00Z'));
+    // Moon phases shift over a month — either phase or name should differ
+    const different = date1.phase !== date2.phase || date1.name !== date2.name;
+    expect(different).toBe(true);
+  });
+
+  it('all 8 phase names are reachable', () => {
+    // Check several dates across a lunar cycle to hit different phases
+    const names = new Set();
+    // Sample dates roughly 3.7 days apart across one synodic month
+    const baseDate = new Date('2025-03-15T00:00:00Z');
+    for (let i = 0; i < 8; i++) {
+      const d = new Date(baseDate.getTime() + i * 3.7 * 24 * 60 * 60 * 1000);
+      names.add(getMoonPhase(d).name);
+    }
+    // Should hit at least 5 of 8 phases in a rough sampling
+    expect(names.size).toBeGreaterThanOrEqual(5);
+  });
+});

--- a/tests/unit/openmeteo.test.js
+++ b/tests/unit/openmeteo.test.js
@@ -180,6 +180,10 @@ describe('normalizeToOwmShape', () => {
       visibility: [
         16000, 16000, 16000, 14000, 12000, 12000, 14000, 16000, 16000, 16000, 16000, 14000, 12000,
         12000, 14000, 16000
+      ],
+      pressure_msl: [
+        1010, 1011, 1012, 1013, 1015, 1016, 1014, 1012, 1011, 1010, 1011, 1012, 1013, 1014, 1013,
+        1012
       ]
     },
     daily: {
@@ -492,5 +496,100 @@ describe('normalizeToOwmShape', () => {
       airQuality: { current: null, hourly: {}, daily: {} }
     });
     expect(data.current.precip_probability).toBeUndefined();
+  });
+
+  it('computes pressure_trend as rising when pressure increased over 3 hours', () => {
+    const data = normalizeToOwmShape({
+      place,
+      forecast,
+      airQuality: { current: null, hourly: {}, daily: {} }
+    });
+    // curIdx = 4 (12:00), curIdx-3 = 1 (03:00), pressure 1011 -> 1015 = +4.0
+    expect(data.current.pressure_trend).toEqual({
+      trend: 'rising',
+      delta: 4.0,
+      pressure_3h_ago: 1011
+    });
+  });
+
+  it('computes pressure_trend as falling when pressure decreased over 3 hours', () => {
+    const fallingForecast = {
+      ...forecast,
+      current: {
+        ...forecast.current,
+        pressure_msl: 1005
+      },
+      hourly: {
+        ...forecast.hourly,
+        pressure_msl: [
+          1013, 1012, 1011, 1010, 1009, 1008, 1007, 1006, 1005, 1004, 1003, 1002, 1001, 1000, 999,
+          998
+        ]
+      }
+    };
+    const data = normalizeToOwmShape({
+      place,
+      forecast: fallingForecast,
+      airQuality: { current: null, hourly: {}, daily: {} }
+    });
+    // curIdx = 4 (12:00), curIdx-3 = 1 (03:00), pressure 1012 -> 1005 = -7.0
+    expect(data.current.pressure_trend.trend).toBe('falling');
+    expect(data.current.pressure_trend.delta).toBe(-7.0);
+  });
+
+  it('computes pressure_trend as steady when pressure change is small', () => {
+    const steadyForecast = {
+      ...forecast,
+      current: {
+        ...forecast.current,
+        pressure_msl: 1015
+      },
+      hourly: {
+        ...forecast.hourly,
+        pressure_msl: [
+          1015, 1015, 1015, 1015, 1015, 1015, 1015, 1015, 1015, 1015, 1015, 1015, 1015, 1015, 1015,
+          1015
+        ]
+      }
+    };
+    const data = normalizeToOwmShape({
+      place,
+      forecast: steadyForecast,
+      airQuality: { current: null, hourly: {}, daily: {} }
+    });
+    expect(data.current.pressure_trend.trend).toBe('steady');
+    expect(data.current.pressure_trend.delta).toBe(0.0);
+  });
+
+  it('sets pressure_trend to null when hourly pressure data is missing', () => {
+    const noPressureForecast = {
+      ...forecast,
+      hourly: {
+        ...forecast.hourly,
+        pressure_msl: undefined
+      }
+    };
+    const data = normalizeToOwmShape({
+      place,
+      forecast: noPressureForecast,
+      airQuality: { current: null, hourly: {}, daily: {} }
+    });
+    expect(data.current.pressure_trend).toBeNull();
+  });
+
+  it('sets pressure_trend to null when curIdx is less than 3', () => {
+    const earlyTimeForecast = {
+      ...forecast,
+      current: {
+        ...forecast.current,
+        time: '2026-04-26T00:00'
+      }
+    };
+    const data = normalizeToOwmShape({
+      place,
+      forecast: earlyTimeForecast,
+      airQuality: { current: null, hourly: {}, daily: {} }
+    });
+    expect(data.current.pressure_trend).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Two new features for the current weather display, closing the last feature gaps with wttr.in.

### Feature 1: Barometric Pressure Trend
Compares current sea-level pressure to 3 hours ago using hourly data already available from Open-Meteo. Shows rising (blue), falling (red), or steady (gray) tendency with the delta in hPa. This is the single most useful indicator for short-term weather forecasting -- rising pressure means fair weather is coming, falling means storm risk.

- Adds `pressure_msl` to the hourly API params
- Computes trend in `normalizeToOwmShape` with edge-case guards for missing/insufficient data
- `formatPressureTrend` display function with color-coded arrows
- 11 new tests (5 openmeteo, 6 display)

### Feature 2: Moon Phase
Pure astronomical math -- no API dependency, no new packages. Calculates the moon phase from the Julian date and synodic period, returns phase name, illumination percentage, and Unicode emoji.

- New `src/utils/moon.js` with `getMoonPhase()` function
- `formatMoonPhase` display function, adds Moon line to the right column
- 14 new tests (10 moon, 4 display)
- Known-date validation: 2025-01-13 (Wolf Moon, >90% illuminated) and 2025-01-29 (new moon, <10%)

## Test Results
- 477 tests passing (18 test files), up from 452
- Lint: clean
- Format: clean
- No new dependencies

## Commits
1. `feat: add barometric pressure trend indicator to current weather`
2. `feat: add moon phase with illumination percentage to current weather`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added moon phase details to the current weather view, including phase name, emoji, and illumination.
  * Added barometric pressure trend information to the pressure display, showing whether pressure is rising, falling, or steady.
* **Bug Fixes**
  * Improved weather data handling so pressure readings and trend information are shown consistently when available.
* **Tests**
  * Expanded unit coverage for pressure trend formatting, moon phase formatting, and moon phase calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->