### PR TITLE
feat: add CAPE thunderstorm potential and solar radiation to current weather

### DIFF
--- a/src/api/openmeteo.js
+++ b/src/api/openmeteo.js
@@ -202,7 +202,8 @@ export async function fetchForecast(lat, lon, { tempUnit, windUnit, includeMinut
       'wind_gusts_10m',
       'cloud_cover',
       'uv_index',
-      'dew_point_2m'
+      'dew_point_2m',
+      'cape'
     ].join(','),
     hourly: [
       'temperature_2m',
@@ -442,6 +443,7 @@ export function normalizeToOwmShape({ place, forecast, airQuality, windUnit = 'm
       visibility: visibilityMeters,
       dew_point: cur.dew_point_2m,
       cloud_cover: cur.cloud_cover,
+      cape: cur.cape ?? null,
       precip_probability: daily.precipitation_probability?.[0],
       pressure_trend: pressureTrend,
       dt

--- a/src/api/openmeteo.js
+++ b/src/api/openmeteo.js
@@ -212,7 +212,8 @@ export async function fetchForecast(lat, lon, { tempUnit, windUnit, includeMinut
       'wind_direction_10m',
       'relative_humidity_2m',
       'pressure_msl',
-      'visibility'
+      'visibility',
+      'shortwave_radiation'
     ].join(','),
     daily: [
       'weather_code',
@@ -444,6 +445,7 @@ export function normalizeToOwmShape({ place, forecast, airQuality, windUnit = 'm
       dew_point: cur.dew_point_2m,
       cloud_cover: cur.cloud_cover,
       cape: cur.cape ?? null,
+      solar_radiation: hourly.shortwave_radiation?.[curIdx] ?? null,
       precip_probability: daily.precipitation_probability?.[0],
       pressure_trend: pressureTrend,
       dt

--- a/src/display.js
+++ b/src/display.js
@@ -139,6 +139,22 @@ function formatCape(value) {
   return chalk.red(`${v} J/kg (extreme)`);
 }
 
+/**
+ * Format solar radiation value with intensity label.
+ * @param {number|null|undefined} value - Solar irradiance in W/m2
+ * @returns {string} Formatted string like "500 W/m2 (strong)" or "N/A"
+ */
+function formatSolarRadiation(value) {
+  if (value === null || value === undefined || Number.isNaN(value)) return 'N/A';
+  const v = Math.round(value);
+  if (v === 0) return '0 W/m2 (night)';
+  if (v < 100) return chalk.gray(`${v} W/m2 (weak)`);
+  if (v < 300) return `${v} W/m2 (moderate)`;
+  if (v < 600) return `${v} W/m2 (strong)`;
+  if (v < 1000) return `${v} W/m2 (very strong)`;
+  return chalk.red(`${v} W/m2 (extreme)`);
+}
+
 function createDataRow(label, value, options = {}) {
   const { labelWidth = 20, icon = '' } = options;
   const formattedLabel = icon ? `${icon} ${label}` : label;
@@ -438,6 +454,7 @@ function displayCurrentWeather(data, displayUnit, options = {}) {
     `Sunset:      ${formatTime(weather.sys.sunset)} (${formatRelativeTime(weather.sys.sunset)})`,
     `Daylight:    ${formatDaylight(weather.sys.sunrise, weather.sys.sunset)}`,
     `Moon:        ${formatMoonPhase(getMoonPhase())}`,
+    `Solar:      ${formatSolarRadiation(weather.solar_radiation)}`,
     aqi ? `Air Quality: ${getAirQualityDescription(aqi)} (AQI: ${aqi})` : '',
     `Min/Max:     ${formatTemp(weather.main.temp_min, displayUnit, { colorCode: true, type: 'min' })} / ${formatTemp(weather.main.temp_max, displayUnit, { colorCode: true, type: 'max' })}`,
     `Wind:        ${wind} (${formatWindDescription(weather.wind.speed, windUnit)})`,
@@ -795,5 +812,6 @@ export {
   formatPressureTrend,
   formatMoonPhase,
   formatCape,
+  formatSolarRadiation,
   createDataRow
 };

--- a/src/display.js
+++ b/src/display.js
@@ -124,6 +124,21 @@ function formatDewPoint(value, displayUnit) {
   return `${Math.round(celsius)}°C (${comfort})`;
 }
 
+/**
+ * Format CAPE (convective available potential energy) value with thunderstorm risk label.
+ * @param {number|null|undefined} value - CAPE in J/kg
+ * @returns {string} Formatted string like "1500 J/kg (moderate)" or "N/A"
+ */
+function formatCape(value) {
+  if (value === null || value === undefined || Number.isNaN(value)) return 'N/A';
+  const v = Math.round(value);
+  if (v < 0) return '0 J/kg (none)';
+  if (v < 1000) return chalk.gray(`${v} J/kg (low)`);
+  if (v < 2500) return chalk.yellow(`${v} J/kg (moderate)`);
+  if (v < 4000) return chalk.red(`${v} J/kg (high)`);
+  return chalk.red(`${v} J/kg (extreme)`);
+}
+
 function createDataRow(label, value, options = {}) {
   const { labelWidth = 20, icon = '' } = options;
   const formattedLabel = icon ? `${icon} ${label}` : label;
@@ -414,7 +429,8 @@ function displayCurrentWeather(data, displayUnit, options = {}) {
     `Pressure:   ${weather.main.pressure} hPa ${formatPressureTrend(weather.pressure_trend?.trend, weather.pressure_trend?.delta)}`,
     `Dew Point:  ${formatDewPoint(weather.dew_point, displayUnit)}`,
     `Cloud Cover: ${weather.cloud_cover ?? 'N/A'}%`,
-    `Rain Chance:  ${formatPrecipProbability(weather.precip_probability)}%`
+    `Rain Chance:  ${formatPrecipProbability(weather.precip_probability)}%`,
+    `CAPE:       ${formatCape(weather.cape)}`
   ];
 
   const right = [
@@ -778,5 +794,6 @@ export {
   formatDaylight,
   formatPressureTrend,
   formatMoonPhase,
+  formatCape,
   createDataRow
 };

--- a/tests/unit/display.test.js
+++ b/tests/unit/display.test.js
@@ -15,6 +15,7 @@ import {
   formatDaylight,
   formatPressureTrend,
   formatMoonPhase,
+  formatCape,
   createDataRow,
   displayAlerts,
   displayMinutelyForecast,
@@ -797,5 +798,67 @@ describe('formatMoonPhase', () => {
     const result = formatMoonPhase(moonData);
     expect(result).toContain('Waxing Crescent');
     expect(result).toContain('15%');
+  });
+});
+
+describe('formatCape', () => {
+  it('returns "N/A" for null', () => {
+    expect(formatCape(null)).toBe('N/A');
+  });
+
+  it('returns "N/A" for undefined', () => {
+    expect(formatCape(undefined)).toBe('N/A');
+  });
+
+  it('returns "N/A" for NaN', () => {
+    expect(formatCape(NaN)).toBe('N/A');
+  });
+
+  it('returns none for negative values', () => {
+    expect(formatCape(-100)).toBe('0 J/kg (none)');
+  });
+
+  it('returns low for value 0', () => {
+    expect(formatCape(0)).toContain('0 J/kg (low)');
+  });
+
+  it('returns low for value 500', () => {
+    expect(formatCape(500)).toContain('500 J/kg (low)');
+  });
+
+  it('returns low for value 999', () => {
+    expect(formatCape(999)).toContain('999 J/kg (low)');
+  });
+
+  it('returns moderate for value 1000', () => {
+    expect(formatCape(1000)).toContain('1000 J/kg (moderate)');
+  });
+
+  it('returns moderate for value 1500', () => {
+    expect(formatCape(1500)).toContain('1500 J/kg (moderate)');
+  });
+
+  it('returns moderate for value 2499', () => {
+    expect(formatCape(2499)).toContain('2499 J/kg (moderate)');
+  });
+
+  it('returns high for value 2500', () => {
+    expect(formatCape(2500)).toContain('2500 J/kg (high)');
+  });
+
+  it('returns high for value 3999', () => {
+    expect(formatCape(3999)).toContain('3999 J/kg (high)');
+  });
+
+  it('returns extreme for value 4000', () => {
+    expect(formatCape(4000)).toContain('4000 J/kg (extreme)');
+  });
+
+  it('returns extreme for value 5000', () => {
+    expect(formatCape(5000)).toContain('5000 J/kg (extreme)');
+  });
+
+  it('rounds decimal values', () => {
+    expect(formatCape(1499.6)).toContain('1500 J/kg (moderate)');
   });
 });

--- a/tests/unit/display.test.js
+++ b/tests/unit/display.test.js
@@ -16,6 +16,7 @@ import {
   formatPressureTrend,
   formatMoonPhase,
   formatCape,
+  formatSolarRadiation,
   createDataRow,
   displayAlerts,
   displayMinutelyForecast,
@@ -860,5 +861,83 @@ describe('formatCape', () => {
 
   it('rounds decimal values', () => {
     expect(formatCape(1499.6)).toContain('1500 J/kg (moderate)');
+  });
+});
+
+describe('formatSolarRadiation', () => {
+  it('returns "N/A" for null', () => {
+    expect(formatSolarRadiation(null)).toBe('N/A');
+  });
+
+  it('returns "N/A" for undefined', () => {
+    expect(formatSolarRadiation(undefined)).toBe('N/A');
+  });
+
+  it('returns "N/A" for NaN', () => {
+    expect(formatSolarRadiation(NaN)).toBe('N/A');
+  });
+
+  it('returns night for value 0', () => {
+    expect(formatSolarRadiation(0)).toBe('0 W/m2 (night)');
+  });
+
+  it('returns weak for value 1', () => {
+    expect(formatSolarRadiation(1)).toContain('1 W/m2 (weak)');
+  });
+
+  it('returns weak for value 50', () => {
+    expect(formatSolarRadiation(50)).toContain('50 W/m2 (weak)');
+  });
+
+  it('returns weak for value 99', () => {
+    expect(formatSolarRadiation(99)).toContain('99 W/m2 (weak)');
+  });
+
+  it('returns moderate for value 100', () => {
+    expect(formatSolarRadiation(100)).toContain('100 W/m2 (moderate)');
+  });
+
+  it('returns moderate for value 200', () => {
+    expect(formatSolarRadiation(200)).toContain('200 W/m2 (moderate)');
+  });
+
+  it('returns moderate for value 299', () => {
+    expect(formatSolarRadiation(299)).toContain('299 W/m2 (moderate)');
+  });
+
+  it('returns strong for value 300', () => {
+    expect(formatSolarRadiation(300)).toContain('300 W/m2 (strong)');
+  });
+
+  it('returns strong for value 500', () => {
+    expect(formatSolarRadiation(500)).toContain('500 W/m2 (strong)');
+  });
+
+  it('returns strong for value 599', () => {
+    expect(formatSolarRadiation(599)).toContain('599 W/m2 (strong)');
+  });
+
+  it('returns very strong for value 600', () => {
+    expect(formatSolarRadiation(600)).toContain('600 W/m2 (very strong)');
+  });
+
+  it('returns very strong for value 800', () => {
+    expect(formatSolarRadiation(800)).toContain('800 W/m2 (very strong)');
+  });
+
+  it('returns very strong for value 999', () => {
+    expect(formatSolarRadiation(999)).toContain('999 W/m2 (very strong)');
+  });
+
+  it('returns extreme for value 1000', () => {
+    expect(formatSolarRadiation(1000)).toContain('1000 W/m2 (extreme)');
+  });
+
+  it('returns extreme for value 1200', () => {
+    expect(formatSolarRadiation(1200)).toContain('1200 W/m2 (extreme)');
+  });
+
+  it('rounds decimal values', () => {
+    expect(formatSolarRadiation(149.6)).toContain('150 W/m2 (moderate)');
   });
 });

--- a/tests/unit/openmeteo.test.js
+++ b/tests/unit/openmeteo.test.js
@@ -149,7 +149,8 @@ describe('normalizeToOwmShape', () => {
       wind_speed_10m: 5,
       wind_direction_10m: 270,
       wind_gusts_10m: 9,
-      cloud_cover: 40
+      cloud_cover: 40,
+      cape: 1500
     },
     hourly: {
       time: [
@@ -591,5 +592,28 @@ describe('normalizeToOwmShape', () => {
       airQuality: { current: null, hourly: {}, daily: {} }
     });
     expect(data.current.pressure_trend).toBeNull();
+  });
+
+  it('maps cape from current weather data', () => {
+    const data = normalizeToOwmShape({
+      place,
+      forecast,
+      airQuality: { current: null, hourly: {}, daily: {} }
+    });
+    expect(data.current.cape).toBe(1500);
+  });
+
+  it('sets cape to null when not present in current weather', () => {
+    const forecastNoCape = {
+      ...forecast,
+      current: { ...forecast.current, cape: undefined }
+    };
+    delete forecastNoCape.current.cape;
+    const data = normalizeToOwmShape({
+      place,
+      forecast: forecastNoCape,
+      airQuality: { current: null, hourly: {}, daily: {} }
+    });
+    expect(data.current.cape).toBeNull();
   });
 });

--- a/tests/unit/openmeteo.test.js
+++ b/tests/unit/openmeteo.test.js
@@ -185,7 +185,8 @@ describe('normalizeToOwmShape', () => {
       pressure_msl: [
         1010, 1011, 1012, 1013, 1015, 1016, 1014, 1012, 1011, 1010, 1011, 1012, 1013, 1014, 1013,
         1012
-      ]
+      ],
+      shortwave_radiation: [0, 0, 50, 200, 800, 650, 300, 100, 0, 0, 50, 200, 800, 650, 300, 100]
     },
     daily: {
       time: ['2026-04-26', '2026-04-27', '2026-04-28', '2026-04-29', '2026-04-30'],
@@ -615,5 +616,29 @@ describe('normalizeToOwmShape', () => {
       airQuality: { current: null, hourly: {}, daily: {} }
     });
     expect(data.current.cape).toBeNull();
+  });
+
+  it('maps solar_radiation from hourly data at curIdx', () => {
+    const data = normalizeToOwmShape({
+      place,
+      forecast,
+      airQuality: { current: null, hourly: {}, daily: {} }
+    });
+    // curIdx = 4 (12:00) -> shortwave_radiation[4] = 800
+    expect(data.current.solar_radiation).toBe(800);
+  });
+
+  it('sets solar_radiation to null when not present in hourly data', () => {
+    const forecastNoSolar = {
+      ...forecast,
+      hourly: { ...forecast.hourly }
+    };
+    delete forecastNoSolar.hourly.shortwave_radiation;
+    const data = normalizeToOwmShape({
+      place,
+      forecast: forecastNoSolar,
+      airQuality: { current: null, hourly: {}, daily: {} }
+    });
+    expect(data.current.solar_radiation).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Two new features for the current weather display, pulling additional data from Open-Meteo.

### Feature 1: CAPE (Thunderstorm Potential)
Convective Available Potential Energy in J/kg. Measures energy available for convection; higher values indicate greater thunderstorm risk.

- Adds `cape` to the current API params
- `formatCape` display function with 5 severity tiers: none, low (gray), moderate (yellow), high, extreme (red)
- 17 new tests (2 API + 15 display)

### Feature 2: Solar Radiation
Current solar irradiance in W/m2 from hourly shortwave_radiation data. Useful for solar panel owners, photographers, and outdoor activity planning.

- Adds `shortwave_radiation` to the hourly API params
- `formatSolarRadiation` display function with 6 intensity tiers: night, weak (gray), moderate, strong, very strong, extreme (red)
- 21 new tests (2 API + 19 display)

## Test Results
- 515 tests passing (18 test files), up from 477
- Lint: clean
- Format: clean
- No new dependencies

## Commits
1. `feat: add CAPE thunderstorm potential indicator to current weather`
2. `feat: add solar radiation intensity to current weather`